### PR TITLE
Created database rows cache container

### DIFF
--- a/db/cache.go
+++ b/db/cache.go
@@ -1,0 +1,85 @@
+package db
+
+import (
+	"database/sql"
+)
+
+// CacheRows is a container to store the values from sql.Rows
+type CacheRows struct {
+	rows  [][]interface{}
+	index int
+	err   error
+}
+
+// Reset resets the index to 0 - must be called before iteration
+func (c *CacheRows) Reset() {
+	c.index = 0
+}
+
+// Next iterator
+func (c *CacheRows) Next() bool {
+	c.index++
+	return c.index <= len(c.rows)
+}
+
+// Err returns the error, if any, encountered in the iteration
+func (c *CacheRows) Err() error {
+	return c.err
+}
+
+// Close does nothing, but it's here for backawards compatibility with sql.Rows
+func (c *CacheRows) Close() error {
+	return c.err
+}
+
+// Scan scanner - similar to sql.Rows.Scan, but you must pass in a Scanner type such as: sql.NullString
+func (c *CacheRows) Scan(dest ...sql.Scanner) error {
+	row := c.rows[c.index-1]
+	for i, scanner := range dest {
+		err := scanner.Scan(row[i])
+		if err != nil {
+			c.err = err
+			return err
+		}
+	}
+	return nil
+}
+
+// Fill fill with rows
+func (c *CacheRows) Fill(rows *sql.Rows) error {
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	count := len(columns)
+	values := make([]interface{}, count)
+	scanArgs := make([]interface{}, count)
+	for i := range values {
+		scanArgs[i] = &values[i]
+	}
+
+	c.rows = make([][]interface{}, 0)
+	for rows.Next() {
+		err := rows.Scan(scanArgs...)
+		if err != nil {
+			return err
+		}
+		each := make([]interface{}, 0)
+		for _, v := range values {
+			each = append(each, v)
+		}
+		c.rows = append(c.rows, each)
+	}
+	return nil
+}
+
+// RowCount row count
+func (c *CacheRows) RowCount() int {
+	return len(c.rows)
+}
+
+// Index current index
+func (c *CacheRows) Index() int {
+	return c.index
+}

--- a/db/cache_test.go
+++ b/db/cache_test.go
@@ -1,0 +1,98 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/pinpt/go-common/log"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+var databaseName = "" // fill this out
+var databasePort = 3306
+var databaseHost = "localhost"
+var databseUser = "root"
+var databasePassword = ""
+var databaseTLS = "false"
+
+// TestSQLCache new test
+func TestSQLCache(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	assert.NotEmpty(databaseName)
+
+	ctx := context.Background()
+
+	fakeCommand := createCommand()
+	logger := log.NewCommandLogger(fakeCommand)
+	defer logger.Close()
+
+	cluster, err := GetDBCluster(ctx, fakeCommand, logger, true)
+	defer cluster.Close()
+	assert.NoError(err)
+	assert.NoError(err)
+
+	db := cluster.Replicas
+	table := ""  // fill this out
+	column := "" // fill this out
+	limit := 10
+	assert.NotEmpty(table, column)
+
+	rows, err := db.QueryContext(ctx, fmt.Sprintf("SELECT %v FROM `%s` LIMIT %v", column, table, limit))
+	assert.NoError(err)
+	defer rows.Close()
+
+	cacheRows := &CacheRows{}
+	err = cacheRows.Fill(rows)
+	assert.NoError(err)
+
+	iterations := 5
+	names := []string{}
+	for i := 0; i < iterations; i++ {
+		cacheRows.Reset()
+		for cacheRows.Next() {
+			var name sql.NullString
+			cacheRows.Scan(&name)
+			names = append(names, name.String)
+		}
+	}
+	// With CacheRows we can iterate as much as we can, so the result should be:
+	// iterations * (number of rows)
+	assert.Equal(len(names), limit*iterations)
+
+	// =============================================================================================
+
+	rows, err = db.QueryContext(ctx, fmt.Sprintf("SELECT %v FROM `%s` LIMIT %v", column, table, 10))
+	assert.NoError(err)
+	defer rows.Close()
+	names = []string{}
+	for i := 0; i < iterations; i++ {
+		for rows.Next() {
+			var name sql.NullString
+			rows.Scan(&name)
+			names = append(names, name.String)
+		}
+	}
+	// With sql.Row we can only iterate once
+	assert.Equal(len(names), limit)
+
+}
+
+func createCommand() *cobra.Command {
+	command := &cobra.Command{}
+	command.Flags().String("databaseName", databaseName, "")
+	command.Flags().Int("databasePort", databasePort, "")
+	command.Flags().String("databaseHostname", databaseHost, "")
+	command.Flags().String("databaseUsername", databseUser, "")
+	command.Flags().String("databasePassword", databasePassword, "")
+	command.Flags().String("databaseTLS", databaseTLS, "")
+	command.Flags().String("databaseClusterInitialConnectionURL", "", "")
+	command.Flags().String("databaseClusterURLSuffix", "", "")
+	command.Flags().Int("databaseClusterMaxConnectionsPerServer", 0, "")
+
+	return command
+}

--- a/db/db.go
+++ b/db/db.go
@@ -620,7 +620,7 @@ func TimedQuery(ctx context.Context, logger log.Logger, db *sql.DB, label string
 var queryCache map[string]*CacheRows
 var queryLock sync.RWMutex
 
-// TimedQueryClusterCache calls TimedQueryCluster but first checks if the results are canched
+// TimedQueryClusterCache calls TimedQueryCluster but first checks if the results are cached
 func TimedQueryClusterCache(ctx context.Context, logger log.Logger, db cluster.RDSReadCluster, label string, sql string, args ...interface{}) (*CacheRows, error) {
 	// queryLock.RLock()
 	queryHash := FormatSQL(sql, args...)

--- a/db/db.go
+++ b/db/db.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pinpt/go-common/db/cluster"
@@ -63,6 +64,8 @@ func (d *DB) SQLDB() *sql.DB {
 var dbreg map[string]bool
 
 func init() {
+	queryCache = make(map[string]*CacheRows)
+	queryLock = sync.RWMutex{}
 	dbreg = make(map[string]bool)
 }
 
@@ -612,6 +615,33 @@ func TimedQuery(ctx context.Context, logger log.Logger, db *sql.DB, label string
 		return rows, err
 	}
 	return db.QueryContext(ctx, sql, args...)
+}
+
+var queryCache map[string]*CacheRows
+var queryLock sync.RWMutex
+
+// TimedQueryClusterCache calls TimedQueryCluster but first checks if the results are canched
+func TimedQueryClusterCache(ctx context.Context, logger log.Logger, db cluster.RDSReadCluster, label string, sql string, args ...interface{}) (*CacheRows, error) {
+	// queryLock.RLock()
+	queryHash := FormatSQL(sql, args...)
+	// queryLock.RUnlock()
+	rows, ok := queryCache[queryHash]
+	if !ok {
+		rws, err := TimedQueryCluster(ctx, logger, db, label, sql, args...)
+		if err != nil {
+			return nil, err
+		}
+		queryLock.Lock()
+		rows = &CacheRows{}
+		rows.Fill(rws)
+		rws.Close()
+		queryCache[queryHash] = rows
+		queryLock.Unlock()
+	} else {
+		log.Debug(logger, fmt.Sprintf("repeated_sql=%s", FormatSQL(sql, args...)), "label", label)
+	}
+	rows.Reset()
+	return rows, nil
 }
 
 // TimedQueryCluster will execute query and log out useful information if SQL_DEBUG env is configured to 1 otherwise a normal SQL query


### PR DESCRIPTION
Created a container to store sql.Rows so we can iterate multiple times if we need to.

How to use: 
```
cacheRows := &CacheRows{}
err = cacheRows.Fill(rows)
// iterate as much as you want, but call Reset first!
cacheRows.Reset()
for cacheRows.Next() {
	var namide sql.NullString
	cacheRows.Scan(&id)
}
```