### PR TITLE
Changed default collation and removed charset.

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -63,7 +63,7 @@ func GetDSN(username string, password string, hostname string, port int, name st
 	cfg.User = username
 	cfg.Passwd = password
 	cfg.DBName = name
-	s := "?collation=utf8_unicode_ci&charset=utf8mb4&parseTime=true"
+	s := "?collation=utf8mb4_unicode_ci&parseTime=true"
 	l := len(attrs)
 	addac := true
 	if l > 0 {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -61,47 +61,47 @@ func TestDSNMask(t *testing.T) {
 	assert := assert.New(t)
 
 	dsn := GetDSN("username", "password", "hostname", 3306, "name")
-	assert.Equal("username:password@tcp(hostname:3306)/name?collation=utf8_unicode_ci&charset=utf8mb4&parseTime=true&autocommit=true", dsn)
+	assert.Equal("username:password@tcp(hostname:3306)/name?collation=utf8mb4_unicode_ci&parseTime=true&autocommit=true", dsn)
 	mask := MaskDSN(dsn, "password")
-	assert.Equal("username:*****@tcp(hostname:3306)/name?collation=utf8_unicode_ci&charset=utf8mb4&parseTime=true&autocommit=true", mask)
+	assert.Equal("username:*****@tcp(hostname:3306)/name?collation=utf8mb4_unicode_ci&parseTime=true&autocommit=true", mask)
 
 	dsn = GetDSN("username", "", "hostname", 3306, "name")
-	assert.Equal("username@tcp(hostname:3306)/name?collation=utf8_unicode_ci&charset=utf8mb4&parseTime=true&autocommit=true", dsn)
+	assert.Equal("username@tcp(hostname:3306)/name?collation=utf8mb4_unicode_ci&parseTime=true&autocommit=true", dsn)
 	mask = MaskDSN(dsn, "")
-	assert.Equal("username@tcp(hostname:3306)/name?collation=utf8_unicode_ci&charset=utf8mb4&parseTime=true&autocommit=true", mask)
+	assert.Equal("username@tcp(hostname:3306)/name?collation=utf8mb4_unicode_ci&parseTime=true&autocommit=true", mask)
 
 	dsn = GetDSN("username", "", "hostname", 0, "name")
-	assert.Equal("username@tcp(hostname:3306)/name?collation=utf8_unicode_ci&charset=utf8mb4&parseTime=true&autocommit=true", dsn)
+	assert.Equal("username@tcp(hostname:3306)/name?collation=utf8mb4_unicode_ci&parseTime=true&autocommit=true", dsn)
 }
 
 func TestDSNMaskAdditionalAttributes(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 	dsn := GetDSN("username", "password", "hostname", 3306, "name", "foo=bar", "bar=yes")
-	assert.Equal("username:password@tcp(hostname:3306)/name?collation=utf8_unicode_ci&charset=utf8mb4&parseTime=true&foo=bar&bar=yes&autocommit=true", dsn)
+	assert.Equal("username:password@tcp(hostname:3306)/name?collation=utf8mb4_unicode_ci&parseTime=true&foo=bar&bar=yes&autocommit=true", dsn)
 }
 
 func TestDSNDefaultTLS(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 	dsn := GetDSN("username", "password", "hostname", 3306, "name")
-	assert.Equal("username:password@tcp(hostname:3306)/name?collation=utf8_unicode_ci&charset=utf8mb4&parseTime=true&autocommit=true", dsn)
+	assert.Equal("username:password@tcp(hostname:3306)/name?collation=utf8mb4_unicode_ci&parseTime=true&autocommit=true", dsn)
 }
 
 func TestDSNOverrideTLS(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 	dsn := GetDSN("username", "password", "hostname", 3306, "name", "tls=true")
-	assert.Equal("username:password@tcp(hostname:3306)/name?collation=utf8_unicode_ci&charset=utf8mb4&parseTime=true&tls=true&autocommit=true", dsn)
+	assert.Equal("username:password@tcp(hostname:3306)/name?collation=utf8mb4_unicode_ci&parseTime=true&tls=true&autocommit=true", dsn)
 	dsn = GetDSN("username", "password", "hostname", 3306, "name", "autocommit=false")
-	assert.Equal("username:password@tcp(hostname:3306)/name?collation=utf8_unicode_ci&charset=utf8mb4&parseTime=true&autocommit=false", dsn)
+	assert.Equal("username:password@tcp(hostname:3306)/name?collation=utf8mb4_unicode_ci&parseTime=true&autocommit=false", dsn)
 }
 
 func TestDSNEscapeUsername(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 	dsn := GetDSN("hi mom", "xZ{G{V?X-R:y%l", "hostname", 3306, "name", "tls=true")
-	assert.Equal("hi mom:xZ{G{V?X-R:y%l@tcp(hostname:3306)/name?collation=utf8_unicode_ci&charset=utf8mb4&parseTime=true&tls=true&autocommit=true", dsn)
+	assert.Equal("hi mom:xZ{G{V?X-R:y%l@tcp(hostname:3306)/name?collation=utf8mb4_unicode_ci&parseTime=true&tls=true&autocommit=true", dsn)
 }
 
 type testTest string


### PR DESCRIPTION
From the driver docs.
"Usage of the charset parameter is discouraged because it issues additional queries to the server. Unless you need the fallback behavior, please use collation instead."
https://github.com/go-sql-driver/mysql

Switched collation from utf8_unicode_ci to utf8mb4_unicode_ci to compensate. utf8 is the alias to utf8mb3 and does not support 4 byte characters.

https://dev.mysql.com/doc/refman/5.5/en/charset-unicode.html