### PR TITLE
DE-1352 kafka producer queue buffering adjustment

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -138,8 +138,12 @@ func (p *Producer) Close() error {
 // NewProducer returns a new Producer instance
 func NewProducer(config Config) (*Producer, error) {
 	c := NewConfigMap(config)
+	// See below link for other configuration options
+	// https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
 	c.SetKey("compression.codec", "snappy")
 	c.SetKey("go.delivery.reports", false)
+	c.SetKey("queue.buffering.max.messages", 500000) // defaults to 100000
+	c.SetKey("queue.buffering.max.ms", 1)            //defaults to 0.5
 	producer, err := ck.NewProducer(c)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**JIRA:** https://pinpt-hq.atlassian.net/browse/DE-1352

**Description:**
adjusting kafka producer config based on issues seen in performance signals.