### PR TITLE
add uploader system

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -35,9 +35,6 @@ const DefaultUploadPartSize = MinUploadPartSize
 // using Upload().
 const DefaultUploadConcurrency = 5
 
-// MaxAttemptsForPart is the max number of attempts for a part before failing
-const MaxAttemptsForPart = 10
-
 // Options for configuring the upload
 type Options struct {
 	// The buffer size (in bytes) to use when buffering data into chunks and

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -1,0 +1,201 @@
+package upload
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pinpt/go-common/api"
+	"github.com/pinpt/httpclient"
+)
+
+// NOTE: these defaults are borrowed from https://github.com/aws/aws-sdk-go/blob/master/service/s3/s3manager/upload.go
+
+// MaxUploadParts is the maximum allowed number of parts in a multi-part upload
+// on Amazon S3.
+const MaxUploadParts = 10000
+
+// MinUploadPartSize is the minimum allowed part size when uploading a part to
+// Amazon S3.
+const MinUploadPartSize int64 = 1024 * 1024 * 5
+
+// DefaultUploadPartSize is the default part size to buffer chunks of a
+// payload into.
+const DefaultUploadPartSize = MinUploadPartSize
+
+// DefaultUploadConcurrency is the default number of goroutines to spin up when
+// using Upload().
+const DefaultUploadConcurrency = 5
+
+// MaxAttemptsForPart is the max number of attempts for a part before failing
+const MaxAttemptsForPart = 10
+
+// Options for configuring the upload
+type Options struct {
+	// The buffer size (in bytes) to use when buffering data into chunks and
+	// sending them as parts to S3. The minimum allowed part size is 5MB, and
+	// if this value is set to zero, the DefaultUploadPartSize value will be used.
+	PartSize int64
+
+	// The number of goroutines to spin up in parallel per call to Upload when
+	// sending parts. If this is set to zero, the DefaultUploadConcurrency value
+	// will be used.
+	//
+	// The concurrency pool is not shared between calls to Upload.
+	Concurrency int
+
+	// AttemptsForPart is the max number of attempts to retry (if failed) before
+	// given up. Defaults to MaxAttemptsForPart
+	AttemptsForPart int
+
+	// Cookies is the cookie headers that must be set to provide permission
+	// for uploading
+	Cookies []string
+
+	// Body is the content to upload
+	Body io.ReadCloser
+
+	// ContentType is the body content type
+	ContentType string
+
+	// URL to upload the parts to
+	URL string
+
+	// Job information about the upload which will be saved into a file named job.json in the same folder
+	Job map[string]interface{}
+}
+
+type part struct {
+	index  int
+	reader io.Reader
+}
+
+func newClient() (httpclient.Client, error) {
+	hcConfig := &httpclient.Config{
+		Paginator: httpclient.NoPaginator(),
+		Retryable: httpclient.NewBackoffRetry(10*time.Millisecond, 100*time.Millisecond, 30*time.Second, 2.0),
+	}
+	return api.NewHTTPAPIClient(hcConfig)
+}
+
+func upload(opts Options, urlpath string, reader io.Reader) error {
+	client, err := newClient()
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPut, urlpath, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Cookie", strings.Join(opts.Cookies, "; "))
+	req.Header.Set("x-amz-acl", "bucket-owner-full-control")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode == http.StatusOK {
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+		return nil
+	}
+	return fmt.Errorf("error uploading %v. status code was %v after multi attempts", urlpath, resp.StatusCode)
+}
+
+// Upload a file to the upload server in multi part upload
+func Upload(opts Options) (int, error) {
+	if opts.PartSize <= 0 || opts.PartSize < MinUploadPartSize {
+		opts.PartSize = DefaultUploadPartSize
+	}
+	if opts.Concurrency <= 0 {
+		opts.Concurrency = DefaultUploadConcurrency
+	}
+	if len(opts.Cookies) == 0 {
+		return 0, fmt.Errorf("missing required Cookies")
+	}
+	if opts.AttemptsForPart <= 0 || opts.AttemptsForPart > MaxAttemptsForPart {
+		opts.AttemptsForPart = MaxAttemptsForPart
+	}
+	if opts.Body == nil {
+		return 0, fmt.Errorf("missing required Body")
+	}
+	if opts.ContentType == "" {
+		return 0, fmt.Errorf("missing required ContentType")
+	}
+	if opts.URL == "" {
+		return 0, fmt.Errorf("missing required URL")
+	}
+	var wg sync.WaitGroup
+	ch := make(chan part, opts.Concurrency)
+	errors := make(chan error, opts.Concurrency)
+	for i := 0; i < opts.Concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for r := range ch {
+				if err := upload(opts, fmt.Sprintf("%s.%d", opts.URL, r.index), r.reader); err != nil {
+					errors <- err
+					return
+				}
+			}
+		}()
+	}
+	var index int
+	// split the buffer in chunks of PartSize and upload each part separately
+	// in its own goroutine
+	for {
+		buf := make([]byte, opts.PartSize)
+		n, err := opts.Body.Read(buf)
+		if err == io.EOF || n < 0 {
+			break
+		}
+		if err != nil {
+			return 0, err
+		}
+		var ok bool
+		for !ok {
+			select {
+			case ch <- part{reader: bytes.NewBuffer(buf[:n]), index: index}:
+				ok = true
+				break
+			default:
+				// check to make sure not in an error state
+				select {
+				case err := <-errors:
+					return 0, err
+				default:
+				}
+				time.Sleep(time.Microsecond)
+			}
+		}
+		index++
+	}
+	close(ch)
+	wg.Wait()
+	opts.Body.Close() // close the body after done
+	select {
+	case err := <-errors:
+		return 0, err
+	default:
+	}
+	// upload the job if we have one once we're done
+	if opts.Job != nil {
+		u, _ := url.Parse(opts.URL)
+		u.Path = path.Join(path.Dir(u.Path), "job.json")
+		buf, err := json.Marshal(opts.Job)
+		if err != nil {
+			return 0, fmt.Errorf("error serializing the job: %v", err)
+		}
+		if err := upload(opts, u.String(), bytes.NewReader(buf)); err != nil {
+			return 0, fmt.Errorf("error uploading job.json: %v", err)
+		}
+	}
+	return index, nil
+}


### PR DESCRIPTION
this PR adds a new package for multi-part uploading to s3 via cloudfront.

we need to support both custom domains for s3 (via cloudfront) as well as we need safe and reliable multi-part uploads.  however, doing both on AWS at this moment is almost impossible.  so we are handling this ourselves.

here's how it works:

- the agent will get a URL via a normal agent.ExportRequest with the url as well as headers to set
- the event machine will generate the URL and the headers by using the cloudfront pre-signed cookies (vs the current one-time s3 presigned url). this is a different api but allows us to create a custom policy specific to the one time directory that allows the client to upload as many parts as needed using the same policy
- the uploader will upload the file in parts (by default split in 5MB boundry but this is configurable).
- the uploader will retry each part up to 30s with exponential backoff to help with flaky proxy servers, etc

this is done in go-common since we can use this for other use cases beyond the agent.

Bert and I tested this for OSX, Linux and Windows with the 2 problem environments (one proxy server, one not).

I will prepare a PR for agent, eventmachine and datamodel and once done, i will merge later tonight and do integration testing together.