### PR TITLE
add EpochMinuteApart⏰

### DIFF
--- a/datetime/time.go
+++ b/datetime/time.go
@@ -8,52 +8,61 @@ import (
 )
 
 const (
-	SignalTimeUnit_NOW          int32 = 0
-	SignalTimeUnit_MONTH        int32 = 30
-	SignalTimeUnit_QUARTER      int32 = 90
-	SignalTimeUnit_HALFYEAR     int32 = 180
-	SignalTimeUnit_YEAR         int32 = 365
-	SignalTimeUnit_THIRDQUARTER int32 = 270
-	SignalTimeUnit_ALLTIME      int32 = -1
-	SignalTimeUnit_BIMONTH      int32 = 60
-	DaysInMilliseconds          int64 = 86400000
+	// SignalTimeUnitNOW is now
+	SignalTimeUnitNOW int32 = 0
+	// SignalTimeUnitMONTH is 30 days
+	SignalTimeUnitMONTH int32 = 30
+	// SignalTimeUnitQUARTER is 90 days
+	SignalTimeUnitQUARTER int32 = 90
+	// SignalTimeUnitHALFYEAR is 180 days
+	SignalTimeUnitHALFYEAR int32 = 180
+	// SignalTimeUnitYEAR is 365 days
+	SignalTimeUnitYEAR int32 = 365
+	// SignalTimeUnitTHIRDQUARTER is 270 days
+	SignalTimeUnitTHIRDQUARTER int32 = 270
+	// SignalTimeUnitALLTIME is all time
+	SignalTimeUnitALLTIME int32 = -1
+	// SignalTimeUnitBIMONTH is two month
+	SignalTimeUnitBIMONTH int32 = 60
+	// DaysInMilliseconds is one day in milliseconds
+	DaysInMilliseconds int64 = 86400000
 )
 
-// RFC3339
-// There is an edge case where there is no timezone set
+// RFC3339 There is an edge case where there is no timezone set
 // and that makes the format function return dates like
 // 2019-09-03T20:48:57.073Z.
 // We are using this RFC3339 custom format to
 // always get an offset.
 const RFC3339 = "2006-01-02T15:04:05.999999999-07:00"
 
+// GetTimeUnitString will return the timeunit as a string
 func GetTimeUnitString(timeUnit int32) string {
 	switch timeUnit {
-	case SignalTimeUnit_NOW:
+	case SignalTimeUnitNOW:
 		{
 			return "now"
 		}
-	case SignalTimeUnit_MONTH:
+	case SignalTimeUnitMONTH:
 		{
 			return "month"
 		}
-	case SignalTimeUnit_QUARTER:
+	case SignalTimeUnitQUARTER:
 		{
 			return "quarter"
 		}
-	case SignalTimeUnit_BIMONTH:
+	case SignalTimeUnitBIMONTH:
 		{
 			return "bimonth"
 		}
-	case SignalTimeUnit_HALFYEAR:
+	case SignalTimeUnitHALFYEAR:
 		{
 			return "halfyear"
 		}
-	case SignalTimeUnit_THIRDQUARTER:
+	case SignalTimeUnitTHIRDQUARTER:
 		{
 			return "thirdquarter"
 		}
-	case SignalTimeUnit_YEAR:
+	case SignalTimeUnitYEAR:
 		{
 			return "year"
 		}
@@ -206,31 +215,31 @@ func ToTimeRange(tv time.Time, days int) (int64, int64) {
 // GetSignalDate returns a metric date in short form for a time unit from the ref date
 func GetSignalDate(timeUnit int32, refDate time.Time) string {
 	switch timeUnit {
-	case SignalTimeUnit_NOW:
+	case SignalTimeUnitNOW:
 		{
 			return ShortDateFromTime(refDate)
 		}
-	case SignalTimeUnit_MONTH:
+	case SignalTimeUnitMONTH:
 		{
 			return ShortDateFromTime(refDate.AddDate(0, 0, -30))
 		}
-	case SignalTimeUnit_BIMONTH:
+	case SignalTimeUnitBIMONTH:
 		{
 			return ShortDateFromTime(refDate.AddDate(0, 0, -60))
 		}
-	case SignalTimeUnit_QUARTER:
+	case SignalTimeUnitQUARTER:
 		{
 			return ShortDateFromTime(refDate.AddDate(0, 0, -90))
 		}
-	case SignalTimeUnit_HALFYEAR:
+	case SignalTimeUnitHALFYEAR:
 		{
 			return ShortDateFromTime(refDate.AddDate(0, 0, -180))
 		}
-	case SignalTimeUnit_THIRDQUARTER:
+	case SignalTimeUnitTHIRDQUARTER:
 		{
 			return ShortDateFromTime(refDate.AddDate(0, 0, -270))
 		}
-	case SignalTimeUnit_YEAR:
+	case SignalTimeUnitYEAR:
 		{
 			return ShortDateFromTime(refDate.AddDate(0, 0, -365))
 		}
@@ -245,31 +254,31 @@ func GetSignalDate(timeUnit int32, refDate time.Time) string {
 func GetSignalTime(timeUnit int32, refDate time.Time) time.Time {
 	var t time.Time
 	switch timeUnit {
-	case SignalTimeUnit_NOW:
+	case SignalTimeUnitNOW:
 		{
 			return refDate.UTC().Truncate(time.Hour * 24)
 		}
-	case SignalTimeUnit_MONTH:
+	case SignalTimeUnitMONTH:
 		{
 			t = refDate.UTC().AddDate(0, 0, -30)
 		}
-	case SignalTimeUnit_BIMONTH:
+	case SignalTimeUnitBIMONTH:
 		{
 			t = refDate.UTC().AddDate(0, 0, -60)
 		}
-	case SignalTimeUnit_QUARTER:
+	case SignalTimeUnitQUARTER:
 		{
 			t = refDate.UTC().AddDate(0, 0, -90)
 		}
-	case SignalTimeUnit_HALFYEAR:
+	case SignalTimeUnitHALFYEAR:
 		{
 			t = refDate.UTC().AddDate(0, 0, -180)
 		}
-	case SignalTimeUnit_THIRDQUARTER:
+	case SignalTimeUnitTHIRDQUARTER:
 		{
 			t = refDate.UTC().AddDate(0, 0, -270)
 		}
-	case SignalTimeUnit_YEAR:
+	case SignalTimeUnitYEAR:
 		{
 			t = refDate.UTC().AddDate(0, 0, -365)
 		}
@@ -283,6 +292,7 @@ func ToMilliSec(date time.Time) int64 {
 	return date.UnixNano() / 1000000
 }
 
+// AddDaysToStrDate will add days to string date
 func AddDaysToStrDate(date string, days int) (string, error) {
 	d, err := time.Parse("2006-01-02", date)
 	if err != nil {
@@ -348,4 +358,18 @@ func NewDateFromEpoch(epoch int64) Date {
 		Rfc3339: val,
 		Offset:  int64(timezone) / 60,
 	}
+}
+
+// EpochMinuteApart returns true if both epochs are less than or equal
+// to one minute apart
+func EpochMinuteApart(epoch1, epoch2 int64) bool {
+	big := epoch1
+	small := epoch2
+	// return tv1.Truncate(time.Minute).Equal(tv2.Truncate(time.Minute))
+	// get the names right
+	if small > big {
+		big = epoch2
+		small = epoch1
+	}
+	return big-small <= 1000*60
 }

--- a/datetime/time_test.go
+++ b/datetime/time_test.go
@@ -118,27 +118,27 @@ func TestGetDateEmpty(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 	assert.Equal("", GetSignalDate(int32(1000), time.Now()))
-	assert.Equal(ShortDateFromTime(time.Now().AddDate(0, 0, -30)), GetSignalDate(SignalTimeUnit_MONTH, time.Now()))
-	assert.Equal(ShortDateFromTime(time.Now().AddDate(0, 0, -60)), GetSignalDate(SignalTimeUnit_BIMONTH, time.Now()))
-	assert.Equal(ShortDateFromTime(time.Now().AddDate(0, 0, -90)), GetSignalDate(SignalTimeUnit_QUARTER, time.Now()))
-	assert.Equal(ShortDateFromTime(time.Now().AddDate(0, 0, -180)), GetSignalDate(SignalTimeUnit_HALFYEAR, time.Now()))
-	assert.Equal(ShortDateFromTime(time.Now().AddDate(0, 0, -365)), GetSignalDate(SignalTimeUnit_YEAR, time.Now()))
-	assert.Equal(ShortDateFromTime(time.Now()), GetSignalDate(SignalTimeUnit_NOW, time.Now()))
-	assert.Equal(ShortDateFromTime(time.Now().AddDate(0, 0, -270)), GetSignalDate(SignalTimeUnit_THIRDQUARTER, time.Now()))
+	assert.Equal(ShortDateFromTime(time.Now().AddDate(0, 0, -30)), GetSignalDate(SignalTimeUnitMONTH, time.Now()))
+	assert.Equal(ShortDateFromTime(time.Now().AddDate(0, 0, -60)), GetSignalDate(SignalTimeUnitBIMONTH, time.Now()))
+	assert.Equal(ShortDateFromTime(time.Now().AddDate(0, 0, -90)), GetSignalDate(SignalTimeUnitQUARTER, time.Now()))
+	assert.Equal(ShortDateFromTime(time.Now().AddDate(0, 0, -180)), GetSignalDate(SignalTimeUnitHALFYEAR, time.Now()))
+	assert.Equal(ShortDateFromTime(time.Now().AddDate(0, 0, -365)), GetSignalDate(SignalTimeUnitYEAR, time.Now()))
+	assert.Equal(ShortDateFromTime(time.Now()), GetSignalDate(SignalTimeUnitNOW, time.Now()))
+	assert.Equal(ShortDateFromTime(time.Now().AddDate(0, 0, -270)), GetSignalDate(SignalTimeUnitTHIRDQUARTER, time.Now()))
 }
 
 func TestGetSignalTime(t *testing.T) {
 	t.Parallel()
 	refTime, _ := time.Parse("2006-01-02T15:04:05Z", "2017-01-31T10:22:00Z")
-	realRefDate := GetSignalTime(SignalTimeUnit_NOW, refTime)
+	realRefDate := GetSignalTime(SignalTimeUnitNOW, refTime)
 	assert := assert.New(t)
 	assert.Equal("2017-01-31 00:00:00 +0000 UTC", realRefDate.String())
-	assert.Equal("2017-01-01 00:00:00 +0000 UTC", GetSignalTime(SignalTimeUnit_MONTH, realRefDate).String())
-	assert.Equal("2016-12-02 00:00:00 +0000 UTC", GetSignalTime(SignalTimeUnit_BIMONTH, realRefDate).String())
-	assert.Equal("2016-11-02 00:00:00 +0000 UTC", GetSignalTime(SignalTimeUnit_QUARTER, realRefDate).String())
-	assert.Equal("2016-08-04 00:00:00 +0000 UTC", GetSignalTime(SignalTimeUnit_HALFYEAR, realRefDate).String())
-	assert.Equal("2016-02-01 00:00:00 +0000 UTC", GetSignalTime(SignalTimeUnit_YEAR, realRefDate).String())
-	assert.Equal("2016-05-06 00:00:00 +0000 UTC", GetSignalTime(SignalTimeUnit_THIRDQUARTER, realRefDate).String())
+	assert.Equal("2017-01-01 00:00:00 +0000 UTC", GetSignalTime(SignalTimeUnitMONTH, realRefDate).String())
+	assert.Equal("2016-12-02 00:00:00 +0000 UTC", GetSignalTime(SignalTimeUnitBIMONTH, realRefDate).String())
+	assert.Equal("2016-11-02 00:00:00 +0000 UTC", GetSignalTime(SignalTimeUnitQUARTER, realRefDate).String())
+	assert.Equal("2016-08-04 00:00:00 +0000 UTC", GetSignalTime(SignalTimeUnitHALFYEAR, realRefDate).String())
+	assert.Equal("2016-02-01 00:00:00 +0000 UTC", GetSignalTime(SignalTimeUnitYEAR, realRefDate).String())
+	assert.Equal("2016-05-06 00:00:00 +0000 UTC", GetSignalTime(SignalTimeUnitTHIRDQUARTER, realRefDate).String())
 }
 
 func TestDateObject(t *testing.T) {
@@ -257,4 +257,35 @@ func TestDateRangeAlltime(t *testing.T) {
 	start, end := DateRange(day, -1)
 	assert.EqualValues(0, start)
 	assert.EqualValues(EndofDay(day.Unix()*1000), end)
+}
+
+func TestEpochSameMinute(t *testing.T) {
+	assert := assert.New(t)
+	// same time
+	now := EpochNow()
+	assert.True(EpochMinuteApart(now, now))
+	// one second apart
+	time1, err := time.Parse(time.RFC3339Nano, "2018-06-04T10:05:49.000-04:00")
+	assert.NoError(err)
+	time2, err := time.Parse(time.RFC3339Nano, "2018-06-04T10:05:50.000-04:00")
+	assert.NoError(err)
+	// different minutes
+	assert.True(EpochMinuteApart(TimeToEpoch(time1), TimeToEpoch(time2)))
+	time1, err = time.Parse(time.RFC3339Nano, "2018-06-04T10:05:49.000-04:00")
+	assert.NoError(err)
+	time2, err = time.Parse(time.RFC3339Nano, "2018-06-04T10:06:00.000-04:00")
+	assert.NoError(err)
+	// one exact minute apart
+	assert.True(EpochMinuteApart(TimeToEpoch(time1), TimeToEpoch(time2)))
+	time1, err = time.Parse(time.RFC3339Nano, "2018-06-04T10:05:49.000-04:00")
+	assert.NoError(err)
+	time2, err = time.Parse(time.RFC3339Nano, "2018-06-04T10:06:49.000-04:00")
+	assert.NoError(err)
+	// over one minute apart
+	assert.True(EpochMinuteApart(TimeToEpoch(time1), TimeToEpoch(time2)))
+	time1, err = time.Parse(time.RFC3339Nano, "2018-06-04T10:05:49.000-04:00")
+	assert.NoError(err)
+	time2, err = time.Parse(time.RFC3339Nano, "2018-06-04T10:06:49.100-04:00")
+	assert.NoError(err)
+	assert.False(EpochMinuteApart(TimeToEpoch(time1), TimeToEpoch(time2)))
 }


### PR DESCRIPTION
**Description:** fixed a bunch of compiler warnings  and added EpochMinuteApart which determines if two epoch dates are within a minute of eachother.