### PR TITLE
log: add ability to truncate long values

### DIFF
--- a/log/cobra.go
+++ b/log/cobra.go
@@ -29,10 +29,15 @@ func RegisterFlags(rootCmd *cobra.Command) {
 	rootCmd.PersistentFlags().String("log-output", "-", "the location of the log file, use - for default or specify a location")
 	rootCmd.PersistentFlags().Bool("log-timestamp", timestamps, "turn on timestamps in output")
 	rootCmd.PersistentFlags().String("log-timestamp-format", "", "timestamp formatting")
+	rootCmd.PersistentFlags().Int("log-maxsize-value", MaxStringValueLength, "the max size of a value when logged")
 }
 
 // NewCommandLogger returns a new Logger for a given command
 func NewCommandLogger(cmd *cobra.Command, opts ...WithLogOptions) LoggerCloser {
+	max, _ := cmd.Flags().GetInt("log-maxsize-value")
+	if max > 0 && max != MaxStringValueLength {
+		MaxStringValueLength = max // allow it to be overriden at the global level. note that if multiple loggers are used one will overwrite the other
+	}
 	pkg := cmd.Name()
 	if opts == nil {
 		opts = make([]WithLogOptions, 0)

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -298,4 +298,7 @@ func TestWithTruncatedStringValue(t *testing.T) {
 	kv := map[string]string{"o": longstring}
 	Debug(log, "key", "val", longstring, "obj", kv) // make sure both the string and the object values are truncated
 	assert.Equal(`DEBUG  test     key            obj=map[o:xxxx(...+17 B) val=xxxxxxxxxx(...+10 B)`, strings.TrimSpace(w.String()))
+	w.Reset()
+	Debug(log, longstring)
+	assert.Equal(`DEBUG  test     xxxxxxxxxx(...+10 B)`, strings.TrimSpace(w.String()))
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -286,4 +287,15 @@ func TestWithTimestamp(t *testing.T) {
 	Debug(log, "hi", "a", "b", "a", "c", "a", "d")
 	ts = time.Now().Format(time.Kitchen)
 	assert.Regexp(regexp.MustCompile(ts+` DEBUG  test     hi                                                 a=d`), w.String())
+}
+
+func TestWithTruncatedStringValue(t *testing.T) {
+	assert := assert.New(t)
+	var w bytes.Buffer
+	log := NewLogger(&w, ConsoleLogFormat, DarkLogColorTheme, DebugLevel, "test")
+	MaxStringValueLength = 10 // make it smaller for the test case
+	longstring := strings.Repeat("x", MaxStringValueLength+10)
+	kv := map[string]string{"o": longstring}
+	Debug(log, "key", "val", longstring, "obj", kv) // make sure both the string and the object values are truncated
+	assert.Equal(`DEBUG  test     key            obj=map[o:xxxx(...+17 B) val=xxxxxxxxxx(...+10 B)`, strings.TrimSpace(w.String()))
 }


### PR DESCRIPTION
**Description:**

- Add ability to have a reasonable default (~10KB) max size of a message or any value when logging
- Add ability to control the max size via `--log-maxsize-value` when using the command logger
