### PR TITLE
manage your own offsets

### DIFF
--- a/kafka/kakfa.go
+++ b/kafka/kakfa.go
@@ -35,7 +35,9 @@ type Config struct {
 	Context                   context.Context
 	Logger                    log.Logger
 	Gzip                      bool
-	GzipMinBytes              int // if not set, defaults to DefaultMinGzipBytes
+	GzipMinBytes              int  // if not set, defaults to DefaultMinGzipBytes
+	IgnoreAssignedOffsets     bool // manage your own assignments
+	ProcessDuration           time.Duration
 }
 
 // NewConfigMap returns a ConfigMap from a Config


### PR DESCRIPTION
- kafka: add support for managing your own offsets for a consumer
- kafka: add support for configuring the warn message on processing a message
