### PR TITLE
Allow more than one topic in action.Register

### DIFF
--- a/event/action/action.go
+++ b/event/action/action.go
@@ -26,7 +26,9 @@ type Config struct {
 	APIKey string
 	// Headers to use when subscribing
 	Headers map[string]string
-	// Topic to use when subscribing
+	// Topics to use when subscribing more than one topic
+	Topics []string
+	// Topic to use when subscribing (deprecadted, use Topics instead)
 	Topic string
 	// Errors is a channel for writing any errors during processing
 	Errors chan<- error
@@ -147,7 +149,6 @@ func Register(ctx context.Context, action Action, config Config) (*ActionSubscri
 	}
 	subscription := event.Subscription{
 		GroupID:           config.GroupID,
-		Topics:            []string{config.Topic},
 		Headers:           config.Headers,
 		Channel:           config.Channel,
 		APIKey:            config.APIKey,
@@ -155,6 +156,11 @@ func Register(ctx context.Context, action Action, config Config) (*ActionSubscri
 		Offset:            config.Offset,
 		Logger:            config.Logger,
 		DisableAutoCommit: true,
+	}
+	if len(config.Topics) > 0 {
+		subscription.Topics = config.Topics
+	} else {
+		subscription.Topics = []string{config.Topic}
 	}
 	ch, err := event.NewSubscription(ctx, subscription)
 	if err != nil {

--- a/event/action/action.go
+++ b/event/action/action.go
@@ -28,7 +28,7 @@ type Config struct {
 	Headers map[string]string
 	// Topics to use when subscribing more than one topic
 	Topics []string
-	// Topic to use when subscribing (deprecadted, use Topics instead)
+	// Topic to use when subscribing
 	Topic string
 	// Errors is a channel for writing any errors during processing
 	Errors chan<- error


### PR DESCRIPTION
With this change, we can pass in more than one topic in the action.Register.

```
sub, err := action.Register(ctx, act, action.Config{
	APIKey:  conf.APIKey,
	GroupID: conf.GroupID,
	Channel: conf.Channel,
	Factory: factory,
	Topics:  []string{ "topic_1", "topic_2", "topic_3"},
	// Topic:  "topic_1", use either "Topic" for one or "Topics" for multiple
	Errors:  errorsChan,
	Offset:  "earliest",
})
```