### PR TITLE
add topic name to eventing.TopicPartition

### DIFF
--- a/eventing/eventing.go
+++ b/eventing/eventing.go
@@ -194,6 +194,7 @@ type ConsumerCallback interface {
 
 // TopicPartition has information about the partition
 type TopicPartition struct {
+	Topic     string
 	Partition int32
 	Offset    int64
 }

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -139,6 +139,7 @@ func toEventingPartitions(topicpartitions []ck.TopicPartition) []eventing.TopicP
 	tp := make([]eventing.TopicPartition, 0)
 	for _, partition := range topicpartitions {
 		tp = append(tp, eventing.TopicPartition{
+			Topic:     *partition.Topic,
 			Partition: partition.Partition,
 			Offset:    int64(partition.Offset),
 		})


### PR DESCRIPTION
add topic partition to the actual TopicPartition so we can use it when more than 1 topic for a consumer
