### PR TITLE
cmd: log improvements

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -38,7 +39,7 @@ var logCmd = &cobra.Command{
 			}
 			var kv map[string]interface{}
 			if err := json.Unmarshal(buf, &kv); err != nil {
-				log.Info(logger, string(buf))
+				log.Info(logger, string(bytes.TrimRight(buf, "\n")))
 				continue
 			}
 			if _, ok := kv["ts"]; !ok {


### PR DESCRIPTION
- improve parsing various different internal formats for level, timestamp etc
- improve parsing agent logs by handling comp -> pkg
- add support for filtering key/value with a special --include option
- add support for filtering on a message regular expression with --message option

you can run like this:

```
stern -n cloudagent ca -o raw | go-common log --log-level debug -i @module=jira-cloud
```

to get beautiful agent logs for the jira integration only


Filtering on a specific message (regexp):

```
stern -n cloudagent ca -o raw | go-common log --log-level debug  -m 'memory use'
```