### PR TITLE
add panic duration to consumer🍔

### DIFF
--- a/kafka/kakfa.go
+++ b/kafka/kakfa.go
@@ -38,6 +38,7 @@ type Config struct {
 	GzipMinBytes              int  // if not set, defaults to DefaultMinGzipBytes
 	IgnoreAssignedOffsets     bool // manage your own assignments
 	ProcessDuration           time.Duration
+	PanicDuration             time.Duration
 }
 
 // NewConfigMap returns a ConfigMap from a Config


### PR DESCRIPTION
**Description:**
- if a panic duration is set on the config then the consumer will panic if it takes that duration or longer to commit a single message