### PR TITLE
TIGR-79 add filter expression engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 .DS_Store
 .idea
+filterexpr/grammar.go

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,17 @@ ORG := pinpt
 PKG := $(ORG)/$(NAME)
 SHELL := /bin/bash
 
-.PHONY: all test
+.PHONY: all test gen
 
 all: test
 
 dependencies:
 	@dep ensure
+	@go get github.com/mna/pigeon
+	$(MAKE) gen
+
+gen:
+	@pigeon ./filterexpr/grammar.peg > ./filterexpr/grammar.go
 
 test:
 	@go test -v ./... | grep -v "no test"

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ all: test
 dependencies:
 	@dep ensure
 	@go get github.com/mna/pigeon
-	$(MAKE) gen
+	@$(MAKE) gen
 
 gen:
-	@pigeon ./filterexpr/grammar.peg > ./filterexpr/grammar.go
+	@go generate ./...
 
 test:
 	@go test -v ./... | grep -v "no test"

--- a/event/action/action.go
+++ b/event/action/action.go
@@ -43,6 +43,8 @@ type Config struct {
 	Logger log.Logger
 	// Temporary if the subscription is temporary and if true, will not receive events if not connected
 	Temporary bool
+	// Filters are the subscription filters for more advanced filtering of subscription results
+	Filters *event.SubscriptionFilter
 }
 
 // Action defines a specific action interface for running an action in response to an event
@@ -51,6 +53,7 @@ type Action interface {
 	Execute(event datamodel.ModelReceiveEvent) (datamodel.ModelSendEvent, error)
 }
 
+// ActionFunc is a callback function for an action
 type ActionFunc func(instance datamodel.ModelReceiveEvent) (datamodel.ModelSendEvent, error)
 
 type action struct {
@@ -163,6 +166,7 @@ func Register(ctx context.Context, action Action, config Config) (*ActionSubscri
 		HTTPHeaders:       config.HTTPHeaders,
 		Temporary:         config.Temporary,
 		DisableAutoCommit: true,
+		Filters:           config.Filters,
 	}
 	if len(config.Topics) > 0 {
 		subscription.Topics = config.Topics

--- a/event/action/action.go
+++ b/event/action/action.go
@@ -43,8 +43,8 @@ type Config struct {
 	Logger log.Logger
 	// Temporary if the subscription is temporary and if true, will not receive events if not connected
 	Temporary bool
-	// Filters are the subscription filters for more advanced filtering of subscription results
-	Filters *event.SubscriptionFilter
+	// Filter are the subscription filters for more advanced filtering of subscription results
+	Filter *event.SubscriptionFilter
 }
 
 // Action defines a specific action interface for running an action in response to an event
@@ -166,7 +166,7 @@ func Register(ctx context.Context, action Action, config Config) (*ActionSubscri
 		HTTPHeaders:       config.HTTPHeaders,
 		Temporary:         config.Temporary,
 		DisableAutoCommit: true,
-		Filters:           config.Filters,
+		Filter:            config.Filter,
 	}
 	if len(config.Topics) > 0 {
 		subscription.Topics = config.Topics

--- a/event/event.go
+++ b/event/event.go
@@ -680,7 +680,7 @@ type Subscription struct {
 	After             int64               `json:"after,omitempty"`
 	DisableAutoCommit bool                `json:"disable_autocommit,omitempty"`
 	Temporary         bool                `json:"temporary,omitempty"`
-	Filters           *SubscriptionFilter `json:"filters,omitempty"`
+	Filter            *SubscriptionFilter `json:"filter,omitempty"`
 	Channel           string              `json:"-"`
 	APIKey            string              `json:"-"`
 	BufferSize        int                 `json:"-"`

--- a/event/event.go
+++ b/event/event.go
@@ -663,25 +663,32 @@ func (c *SubscriptionChannel) run() {
 	log.Debug(c.subscription.Logger, "disconnected")
 }
 
+// SubscriptionFilter are subscription related filters
+type SubscriptionFilter struct {
+	HeadersExpr string `json:"headers,omitempty"`
+	ObjectExpr  string `json:"object,omitempty"`
+}
+
 // Subscription is the information for creating a subscription channel to receive events from the event server
 type Subscription struct {
-	GroupID           string            `json:"group_id"`
-	Topics            []string          `json:"topics"`
-	Headers           map[string]string `json:"headers"`
-	IdleDuration      string            `json:"idle_duration"` // Deprecated
-	Limit             int               `json:"limit"`
-	Offset            string            `json:"offset"` // Deprecated
-	After             int64             `json:"after"`
-	DisableAutoCommit bool              `json:"disable_autocommit"`
-	Temporary         bool              `json:"temporary"`
-	Channel           string            `json:"-"`
-	APIKey            string            `json:"-"`
-	BufferSize        int               `json:"-"`
-	Errors            chan<- error      `json:"-"`
-	Logger            log.Logger        `json:"-"`
-	HTTPHeaders       map[string]string `json:"-"`
-	CloseTimeout      time.Duration     `json:"-"`
-	DispatchTimeout   time.Duration     `json:"-"`
+	GroupID           string              `json:"group_id"`
+	Topics            []string            `json:"topics"`
+	Headers           map[string]string   `json:"headers,omitempty"`
+	IdleDuration      string              `json:"idle_duration,omitempty"` // Deprecated
+	Limit             int                 `json:"limit,omitempty"`
+	Offset            string              `json:"offset,omitempty"` // Deprecated
+	After             int64               `json:"after,omitempty"`
+	DisableAutoCommit bool                `json:"disable_autocommit,omitempty"`
+	Temporary         bool                `json:"temporary,omitempty"`
+	Filters           *SubscriptionFilter `json:"filters,omitempty"`
+	Channel           string              `json:"-"`
+	APIKey            string              `json:"-"`
+	BufferSize        int                 `json:"-"`
+	Errors            chan<- error        `json:"-"`
+	Logger            log.Logger          `json:"-"`
+	HTTPHeaders       map[string]string   `json:"-"`
+	CloseTimeout      time.Duration       `json:"-"`
+	DispatchTimeout   time.Duration       `json:"-"`
 }
 
 // NewSubscription will create a subscription to the event server and will continously read events (as they arrive)

--- a/event/event.go
+++ b/event/event.go
@@ -665,8 +665,8 @@ func (c *SubscriptionChannel) run() {
 
 // SubscriptionFilter are subscription related filters
 type SubscriptionFilter struct {
-	HeadersExpr string `json:"headers,omitempty"`
-	ObjectExpr  string `json:"object,omitempty"`
+	HeaderExpr string `json:"header,omitempty"`
+	ObjectExpr string `json:"object,omitempty"`
 }
 
 // Subscription is the information for creating a subscription channel to receive events from the event server

--- a/filterexpr/filterexpr.go
+++ b/filterexpr/filterexpr.go
@@ -1,0 +1,32 @@
+package filterexpr
+
+import (
+	"strings"
+)
+
+// Filter is a filter which can be evaluated to true or false based on the input map
+type Filter interface {
+	// Test will return true if the filter expression matches the map
+	Test(kv map[string]interface{}) bool
+}
+
+type filter struct {
+	expr *ExpressionGroup
+}
+
+var _ Filter = (*filter)(nil)
+
+// Test will return true if the filter expression matches the map
+func (f *filter) Test(kv map[string]interface{}) bool {
+	return f.expr.Test(kv)
+}
+
+// Compile will compile the filter expression as a string in Filter which can be saved and invoked and is thread safe
+func Compile(expr string) (Filter, error) {
+	object, err := ParseReader("", strings.NewReader(expr), MaxExpressions(5000))
+	if err != nil {
+		return nil, err
+	}
+	// fmt.Println(object)
+	return &filter{object.(*ExpressionGroup)}, nil
+}

--- a/filterexpr/filterexpr.go
+++ b/filterexpr/filterexpr.go
@@ -1,3 +1,5 @@
+//go:generate pigeon -optimize-parser -o grammar.go grammar.peg
+
 package filterexpr
 
 import (

--- a/filterexpr/filterexpr_test.go
+++ b/filterexpr/filterexpr_test.go
@@ -1,0 +1,149 @@
+package filterexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInvalid(t *testing.T) {
+	assert := assert.New(t)
+	filter, err := Compile("a:")
+	assert.EqualError(err, `1:3 (2): no match found, expected: "-", "/", "0", "\"", "false", "true", [ \t\r\n] or [1-9]`)
+	assert.Nil(filter)
+}
+
+func TestSimpleKeyVal(t *testing.T) {
+	assert := assert.New(t)
+	filter, err := Compile(`a:"b"`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": "b"}))
+	assert.False(filter.Test(map[string]interface{}{"a": "a"}))
+}
+
+func TestSimpleKeyValWithSpaces(t *testing.T) {
+	assert := assert.New(t)
+	filter, err := Compile(`a: "b"`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": "b"}))
+	assert.False(filter.Test(map[string]interface{}{"a": "a"}))
+	filter, err = Compile(`a : "b"`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": "b"}))
+	assert.False(filter.Test(map[string]interface{}{"a": "a"}))
+}
+
+func TestSimpleKeyValEscaped(t *testing.T) {
+	assert := assert.New(t)
+	filter, err := Compile(`a:"\"hello\""`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": `"hello"`}))
+}
+
+func TestSimpleKeyValNum(t *testing.T) {
+	assert := assert.New(t)
+	filter, err := Compile(`a:123`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": "123"}))
+	assert.True(filter.Test(map[string]interface{}{"a": 123}))
+	assert.False(filter.Test(map[string]interface{}{"a": "456"}))
+}
+
+func TestSimpleKeyValBool(t *testing.T) {
+	assert := assert.New(t)
+	filter, err := Compile(`a:true`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": true}))
+	assert.False(filter.Test(map[string]interface{}{"a": false}))
+	filter, err = Compile(`a:false`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": false}))
+	assert.False(filter.Test(map[string]interface{}{"a": true}))
+}
+
+func TestSimpleKeyValWithDots(t *testing.T) {
+	assert := assert.New(t)
+	filter, err := Compile(`a.b:"true"`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": true,
+		},
+	}))
+	assert.True(filter.Test(map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": "true",
+		},
+	}))
+	filter, err = Compile(`a.b:true`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": true,
+		},
+	}))
+	assert.True(filter.Test(map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": "true",
+		},
+	}))
+}
+
+func TestWithOR(t *testing.T) {
+	assert := assert.New(t)
+	filter, err := Compile(`a:"b" OR b:"a"`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": "b"}))
+	assert.True(filter.Test(map[string]interface{}{"a": "a", "b": "a"}))
+}
+
+func TestWithAND(t *testing.T) {
+	assert := assert.New(t)
+	filter, err := Compile(`a:"b" AND b:"a"`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": "b", "b": "a"}))
+	assert.False(filter.Test(map[string]interface{}{"a": "b", "b": "c"}))
+}
+
+func TestWithANDGroup(t *testing.T) {
+	assert := assert.New(t)
+	filter, err := Compile(`(a:"a" OR b:"b") AND c:"c"`)
+	assert.NoError(err)
+	assert.False(filter.Test(map[string]interface{}{"a": "a", "b": "b"}))
+	assert.True(filter.Test(map[string]interface{}{"a": "a", "b": "a", "c": "c"}))
+	assert.True(filter.Test(map[string]interface{}{"a": "b", "b": "b", "c": "c"}))
+}
+
+func TestWithORGroup(t *testing.T) {
+	assert := assert.New(t)
+	filter, err := Compile(`(a:"a" OR b:"b") OR (c:"c" d:true)`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": "a", "b": "b", "c": "c", "d": true}))
+	assert.True(filter.Test(map[string]interface{}{"a": "b", "b": "b", "c": "d", "d": false}))
+}
+
+func TestRegexp(t *testing.T) {
+	assert := assert.New(t)
+	filter, err := Compile(`a:/a/`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": "a"}))
+	assert.False(filter.Test(map[string]interface{}{"a": "ABC"}))
+	filter, err = Compile(`a:/(?i)a/`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": "ABC"}))
+	filter, err = Compile(`a:/^a$/`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": "a"}))
+	assert.False(filter.Test(map[string]interface{}{"a": "b"}))
+	filter, err = Compile(`a:/\d+/`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": 123}))
+	filter, err = Compile(`a:/\d{1,3}/`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": 123}))
+	filter, err = Compile(`a:/^admin\./`)
+	assert.NoError(err)
+	assert.True(filter.Test(map[string]interface{}{"a": "admin.Agent"}))
+	assert.True(filter.Test(map[string]interface{}{"a": "admin.AgentLastUpdate"}))
+	assert.False(filter.Test(map[string]interface{}{"a": "adminAgentLastUpdate"}))
+}

--- a/filterexpr/grammar.peg
+++ b/filterexpr/grammar.peg
@@ -1,0 +1,256 @@
+{
+package filterexpr
+
+import (
+    "fmt"
+    "strings"
+    "regexp"
+
+    pjson "github.com/pinpt/go-common/json"
+)
+
+func toIfaceSlice(v interface{}) []interface{} {
+    if v == nil {
+        return nil
+    }
+    return v.([]interface{})
+}
+
+type Node struct {
+    Key string
+    Value string
+    RegExp bool
+    re *regexp.Regexp
+}
+
+func (n *Node) String() string {
+    if n.RegExp {
+        return fmt.Sprintf("Node[%s=~%s]", n.Key, n.Value)
+    }
+    return fmt.Sprintf("Node[%s=%s]", n.Key, n.Value)
+}
+
+func toString(val interface{}) string {
+    if sval, ok := val.(string); ok {
+        return sval
+    }
+    if sval, ok := val.(fmt.Stringer); ok {
+        return sval.String()
+    }
+    return pjson.Stringify(val)
+}
+
+func (n *Node) Test(kv map[string]interface{}) bool {
+    if val, ok := kv[n.Key]; ok {
+        sval := toString(val)
+        if n.RegExp {
+            return n.re.MatchString(sval)
+        }
+        return n.Value == sval
+    }
+    if strings.Contains(n.Key, ".") {
+        val, _ := pjson.DottedFind(n.Key, kv)
+        if val == nil {
+            return false
+        }
+        sval := toString(val)
+        if n.RegExp {
+            return n.re.MatchString(sval)
+        }
+        return n.Value == sval
+    }
+    return n.Value == ""
+}
+
+type Expression struct {
+    Left *Node
+    Conjunction string
+    Right *Expression
+}
+
+func (e *Expression) String() string {
+    return fmt.Sprintf("Expression[%s,%s,%s]", e.Left, e.Conjunction, e.Right)
+}
+
+func (n *Expression) Test(kv map[string]interface{}) bool {
+    if n.Right == nil {
+        return n.Left.Test(kv)
+    }
+    if n.Conjunction == "OR" {
+            return n.Left.Test(kv) || n.Right.Test(kv)
+    }
+    return n.Left.Test(kv) && n.Right.Test(kv)
+}
+
+type ExpressionGroup struct {
+    Left []*Expression
+    Conjunction string
+    Right []*Expression
+}
+
+func (g *ExpressionGroup) String() string {
+    if g.Conjunction == "" {
+       return fmt.Sprintf("ExpressionGroup[%s]", g.Left)
+    }
+    return fmt.Sprintf("ExpressionGroup[%s,%s,%s]", g.Left, g.Conjunction, g.Right)
+}
+
+func (n *ExpressionGroup) Test(kv map[string]interface{}) bool {
+    if len(n.Right) == 0 {
+        for _, e := range n.Left {
+            if !e.Test(kv) {
+                return false
+            }
+        }
+        return true
+    }
+    left := true
+    for _, e := range n.Left {
+        if !e.Test(kv) {
+            left = false
+            break
+        }
+    }
+    right := true
+    for _, e := range n.Right {
+        if !e.Test(kv) {
+            right = false
+            break
+        }
+    }
+    if n.Conjunction == "OR" {
+        return left || right
+    }
+    return left && right
+}
+
+}
+
+Object ← _ val:ExpressionList EOF {
+    return val, nil
+}
+
+Value ← val:( String ) _ {
+    return val, nil
+}
+
+OrCondition ← "OR"
+AndCondition ← "AND"
+
+Condition ← OrCondition / AndCondition
+
+ExpressionList ← _ vals:( ExpressionGroup ( _ Condition ExpressionGroup )? ) {
+    valsSl := toIfaceSlice(vals)
+    res := &ExpressionGroup{}
+    res.Left = valsSl[0].([]*Expression)
+    if len(valsSl) > 1 && valsSl[1] != nil {
+        group := toIfaceSlice(valsSl[1])
+        res.Conjunction = string(group[1].([]byte))
+        res.Right = group[2].([]*Expression)
+    }
+    return res, nil
+}
+
+ExpressionGroup ← _ vals:( _ LeftParen? _ Expression _ RightParen? _ )+ {
+    valsSl := toIfaceSlice(vals)
+    res := make([]*Expression, 0)
+    //fmt.Println("expression group", len(valsSl))
+    for _, val := range valsSl {
+        //fmt.Println("exp group", i, "val", val)
+        res = append(res, toIfaceSlice(val)[3].(*Expression))
+    }
+    return res, nil
+}
+
+Separator ← ':'
+
+NodeVal ← val:( String / Number / Bool / Regexp ) _ {
+    return val, nil
+}
+
+Node ← _ vals:( _ Label _ Separator _ NodeVal _ ) {
+    var res Node
+    valsSl := toIfaceSlice(vals)
+    res.Key = valsSl[1].(string)
+    if re, ok := valsSl[5].(*regexp.Regexp); ok {
+        res.re = re
+        res.RegExp = true
+    } else {
+        res.Value = toString(valsSl[5])
+    }
+    return &res, nil
+}
+
+Expression ← _ vals:( Node ( _ Condition _ Node )* ) {
+    valsSl := toIfaceSlice(vals)
+    left := valsSl[0].(*Node)
+    var right *Expression
+    var current *Expression
+    var conjunction string
+    //fmt.Println("len", len(valsSl))
+    if len(valsSl) > 1 {
+        grouping := toIfaceSlice(valsSl[1])
+        for _, group := range grouping {
+            igroup := toIfaceSlice(group)
+            //fmt.Println(i, "group", igroup)
+            conjunction = string(igroup[1].([]byte))
+            //fmt.Println(i, conjunction)
+            iright := igroup[3].(*Node)
+            //fmt.Println(i, iright)
+            newexp := &Expression{iright, conjunction, nil}
+            if right == nil {
+                right = newexp
+                current = newexp
+            } else {
+                current.Right = newexp
+                current = newexp
+            }
+        }
+    }
+    return &Expression{left, conjunction, right}, nil
+}
+
+Label ← ( [a-zA-Z0-9\\.]* ) {
+    return string(c.text), nil
+}
+
+String ← '"' ( !EscapedChar . / '\\' EscapeSequence )* '"' {
+    c.text = bytes.Replace(c.text, []byte(`\/`), []byte(`/`), -1)
+    return strconv.Unquote(string(c.text))
+}
+
+LeftParen ← "("
+
+RightParen ← ")"
+
+EscapedChar ← [\x00-\x1f"\\]
+
+EscapeSequence ← SingleCharEscape / UnicodeEscape
+
+SingleCharEscape ← ["\\/bfnrt]
+
+UnicodeEscape ← 'u' HexDigit HexDigit HexDigit HexDigit
+
+DecimalDigit ← [0-9]
+
+NonZeroDecimalDigit ← [1-9]
+
+Number ← '-'? Integer ( '.' DecimalDigit+ )? Exponent? {
+    return strconv.ParseFloat(string(c.text), 64)
+}
+
+Integer ← '0' / NonZeroDecimalDigit DecimalDigit*
+
+Exponent ← 'e'i [+-]? DecimalDigit+
+
+Bool ← "true" { return true, nil } / "false" { return false, nil }
+
+HexDigit ← [0-9a-f]i
+
+Regexp ← '/' [A-Za-z0-9^$-._\\(\\)\\?\\+{}]+ '/' {
+    return regexp.Compile(string(c.text[1: len(c.text)-1]))
+}
+
+_ "whitespace" ← [ \t\r\n]*
+
+EOF ← !.

--- a/json/jsonpath_test.go
+++ b/json/jsonpath_test.go
@@ -86,11 +86,11 @@ func TestInvokeActionNoAction(t *testing.T) {
 func TestJSONPathWithNil(t *testing.T) {
 	assert := assert.New(t)
 	val, err := jsonpath.JsonPathLookup(map[string]interface{}{}, "$.foo")
-	assert.True(isJSONPathNotFound(err))
-	assert.True(isJSONPathNil(val))
+	assert.True(IsJSONPathNotFound(err))
+	assert.True(IsJSONPathNil(val))
 	val, err = jsonpath.JsonPathLookup(map[string]interface{}{}, "$.foo.bar")
-	assert.True(isJSONPathNotFound(err))
-	assert.True(isJSONPathNil(val))
+	assert.True(IsJSONPathNotFound(err))
+	assert.True(IsJSONPathNil(val))
 }
 
 func TestCoalesce(t *testing.T) {
@@ -110,4 +110,18 @@ func TestCoalesce(t *testing.T) {
 	result, err = invokeAction("coalesce($.a, $b)", map[string]interface{}{})
 	assert.NoError(err)
 	assert.Nil(result)
+}
+
+func TestDottedFind(t *testing.T) {
+	assert := assert.New(t)
+	ok, err := DottedFind("a.b.c", map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": map[string]interface{}{
+				"c": true,
+			},
+		},
+	})
+	assert.NoError(err)
+	assert.NotNil(ok)
+	assert.Equal(true, ok)
 }


### PR DESCRIPTION
**JIRA:** https://pinpt-hq.atlassian.net/browse/TIGR-79

**Description:**

Adds a filter expression engine with a custom parser grammar using PEG.

Allows us to build filters from maps similar to a very very simplified lucene syntax.

For example, we can match:

```
a: "b"
```

And that will match the following example expression:

```json
{
  "a": "b"
}
```

You can also use conjunctions like:

```
a: "b" OR a: "c"
```

