### PR TITLE
allow changing default log level ✏️

### DIFF
--- a/log/cobra.go
+++ b/log/cobra.go
@@ -23,7 +23,7 @@ func init() {
 // RegisterFlags will register the flags for logging
 func RegisterFlags(rootCmd *cobra.Command) {
 	timestamps := isContainer || !isatty.IsTerminal(os.Stdout.Fd())
-	rootCmd.PersistentFlags().StringP("log-level", "info", pos.Getenv("PP_LOG_LEVEL", "info"), "set the log level")
+	rootCmd.PersistentFlags().String("log-level", pos.Getenv("PP_LOG_LEVEL", "info"), "set the log level")
 	rootCmd.PersistentFlags().String("log-color", "dark", "set the log color profile (dark or light). only applies to console logging")
 	rootCmd.PersistentFlags().String("log-format", "default", "set the log format (json, logfmt, default)")
 	rootCmd.PersistentFlags().String("log-output", "-", "the location of the log file, use - for default or specify a location")

--- a/log/cobra.go
+++ b/log/cobra.go
@@ -23,7 +23,7 @@ func init() {
 // RegisterFlags will register the flags for logging
 func RegisterFlags(rootCmd *cobra.Command) {
 	timestamps := isContainer || !isatty.IsTerminal(os.Stdout.Fd())
-	rootCmd.PersistentFlags().String("log-level", "info", "set the log level")
+	rootCmd.PersistentFlags().StringP("log-level", "info", pos.Getenv("PP_LOG_LEVEL", "info"), "set the log level")
 	rootCmd.PersistentFlags().String("log-color", "dark", "set the log color profile (dark or light). only applies to console logging")
 	rootCmd.PersistentFlags().String("log-format", "default", "set the log format (json, logfmt, default)")
 	rootCmd.PersistentFlags().String("log-output", "-", "the location of the log file, use - for default or specify a location")


### PR DESCRIPTION
**Description:**
Allows setting default log-level for command logger. So that I don't have to add the flag every time I'm piping logs into `go-common log`.

```bash
go-common log --log-level debug
```
becomes:
```bash
# PP_LOG_LEVEL=debug
go-common log
```
it'll still use whatever flag you give it though so if someone sets it to `error`, this shouldn't break any scripts since we're usually explicit