### PR TITLE
simplify join url

### DIFF
--- a/strings/strutil.go
+++ b/strings/strutil.go
@@ -66,12 +66,8 @@ func PrettyTime(t time.Duration) string {
 func JoinURL(elem ...string) string {
 	parts := []string{}
 	for _, e := range elem {
-		if strings.HasSuffix(e, "/") {
-			e = strings.TrimSuffix(e, "/")
-		}
-		if strings.HasPrefix(e, "/") {
-			e = strings.TrimPrefix(e, "/")
-		}
+		e = strings.TrimSuffix(e, "/")
+		e = strings.TrimPrefix(e, "/")
 		parts = append(parts, e)
 	}
 	res := strings.Join(parts, "/")


### PR DESCRIPTION
I wrote this function in my very early days. There is no need to check for `HasSuffix` and `HasPrefix` since the Trim functions already check for that