### PR TITLE
fix double checksum 🤦‍♀️

### DIFF
--- a/fileutil/file.go
+++ b/fileutil/file.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
-	"crypto/sha512"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -13,6 +12,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/pinpt/go-common/v10/hash"
 )
 
 // Resolve with resolve a relative file path
@@ -176,23 +177,18 @@ func AddFileToZip(zipWriter *zip.Writer, dir string, filename string) error {
 	return err
 }
 
-// Checksum will return the sha512 checksum of a file
+// Checksum will return the sha256 checksum of a file
 func Checksum(fn string) (string, error) {
-	hasher := sha512.New()
 	of, err := os.Open(fn)
 	if err != nil {
 		return "", err
 	}
-	for {
-		buf := make([]byte, 8096)
-		n, err := of.Read(buf)
-		if err == io.EOF || n == 0 {
-			break
-		}
-		hasher.Write(buf[0:n])
+	sum, err := hash.Sha256Checksum(of)
+	if err != nil {
+		return "", err
 	}
 	of.Close()
-	sha := hex.EncodeToString(hasher.Sum(nil))
+	sha := hex.EncodeToString(sum)
 	return sha, nil
 }
 

--- a/fileutil/file_test.go
+++ b/fileutil/file_test.go
@@ -203,3 +203,14 @@ func TestOpenNestedZip(t *testing.T) {
 		}
 	}
 }
+
+func TestChecksum(t *testing.T) {
+	assert := assert.New(t)
+	fn := filepath.Join(os.TempDir(), "hashChecksum")
+	assert.NoError(ioutil.WriteFile(fn, []byte("hash me"), 0644))
+	defer os.Remove(fn)
+	sum, err := Checksum(fn)
+	assert.NoError(err)
+	// shasum -a 256 hashChecksum
+	assert.Equal("eb201af5aaf0d60629d3d2a61e466cfc0fedb517add831ecac5235e1daa963d6", sum)
+}

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -1,10 +1,8 @@
 package hash
 
 import (
+	"bytes"
 	"encoding/hex"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -154,10 +152,8 @@ func TestModulo(t *testing.T) {
 
 func TestChecksum(t *testing.T) {
 	assert := assert.New(t)
-	fn := filepath.Join(os.TempDir(), "hashChecksum")
-	assert.NoError(ioutil.WriteFile(fn, []byte("hash me"), 0644))
-	defer os.Remove(fn)
-	buf, err := Checksum(fn)
+	r := bytes.NewReader([]byte("hash me"))
+	buf, err := Sha256Checksum(r)
 	assert.NoError(err)
 	sum := hex.EncodeToString(buf)
 	// shasum -a 256 hashChecksum


### PR DESCRIPTION
**Description:**
- So I accidentally copied *2* checksum methods into 2 different modules in go-common. the one in fileutil was a better implementation so stole the meat of that and put it into hash as `ChecksumFrom` which will let us take checksums of stuff we already have in memory without loading the thing in memory again (yay!) and then used it in fileutil. I just used `sha256` cause thats what we use for generating all our certs/keys. If we want to use `sha512`  for checksums of files instead we should do it now.