### PR TITLE
reconnect after policy violation

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -658,7 +658,7 @@ func (c *SubscriptionChannel) run() {
 		for !closed {
 			var actionresp actionResponse
 			if err := wch.ReadJSON(&actionresp); err != nil {
-				if IsErrorRetryable(err) || websocket.IsCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure, websocket.CloseTryAgainLater, websocket.CloseAbnormalClosure) {
+				if IsErrorRetryable(err) || websocket.IsCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure, websocket.CloseTryAgainLater, websocket.CloseAbnormalClosure, websocket.ClosePolicyViolation) {
 					closed = true
 					errored = true
 					log.Debug(c.subscription.Logger, "connection has been closed, will try to reconnect", "err", err)


### PR DESCRIPTION
My guess is that this policy https://github.com/pinpt/event-api/blob/master/pkg/server/consume.go#L270 is causing this panic in the agents, which is causing long historicals to start over.

```
panic: websocket: close 1008 (policy violation): timed out

goroutine 163 [running]:
```

