### PR TITLE
BOLT-186: Moving GenerateQueueName method to go-common

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -812,6 +812,28 @@ type Subscription struct {
 	CloseTimeout      time.Duration       `json:"-"`
 	DispatchTimeout   time.Duration       `json:"-"`
 	DisablePing       bool                `json:"-"` // Deprecated
+
+	// used internally
+	CustomerID string `json:"-"`
+	Internal   bool   `json:"-"`
+	Anonymous  bool   `json:"-"`
+}
+
+//GenerateQueueName takes in a Subscription, extracts the headers and topics and returns a consistent but unique queue name
+func GenerateQueueName(subscription Subscription) string {
+	hashkeys := []string{}
+	for k, v := range sub.Headers {
+		hashkeys = append(hashkeys, k, v)
+	}
+	for _, topic := range sub.Topics {
+		hashkeys = append(hashkeys, topic)
+	}
+
+	// sort so the hash is consistent
+	sort.Strings(hashkeys)
+	queueName := sub.GroupID + "-" + hash.Values(hashkeys) // has the matching headers and topics so we create a consistent but unique queue
+
+	return queueName
 }
 
 // NewSubscription will create a subscription to the event server and will continously read events (as they arrive)

--- a/event/event.go
+++ b/event/event.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/pinpt/go-common/v10/api"
 	"github.com/pinpt/go-common/v10/datamodel"
+	"github.com/pinpt/go-common/v10/hash"
 	pjson "github.com/pinpt/go-common/v10/json"
 	"github.com/pinpt/go-common/v10/log"
 	pstrings "github.com/pinpt/go-common/v10/strings"
@@ -822,16 +824,16 @@ type Subscription struct {
 //GenerateQueueName takes in a Subscription, extracts the headers and topics and returns a consistent but unique queue name
 func GenerateQueueName(subscription Subscription) string {
 	hashkeys := []string{}
-	for k, v := range sub.Headers {
+	for k, v := range subscription.Headers {
 		hashkeys = append(hashkeys, k, v)
 	}
-	for _, topic := range sub.Topics {
+	for _, topic := range subscription.Topics {
 		hashkeys = append(hashkeys, topic)
 	}
 
 	// sort so the hash is consistent
 	sort.Strings(hashkeys)
-	queueName := sub.GroupID + "-" + hash.Values(hashkeys) // has the matching headers and topics so we create a consistent but unique queue
+	queueName := subscription.GroupID + "-" + hash.Values(hashkeys) // has the matching headers and topics so we create a consistent but unique queue
 
 	return queueName
 }

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -661,3 +661,50 @@ func TestSetHeaders(t *testing.T) {
 	err := Publish(context.Background(), event, "dev", "", WithHeaders(map[string]string{"x-api-key": "foobar"}))
 	assert.NoError(err)
 }
+
+func TestGenerateQueueName(t *testing.T) {
+	assert := assert.New(t)
+	sub1 := Subscription{
+		GroupID: "TestGroup",
+		Topics:  []string{"Topic_1", "Topic_2"},
+	}
+	queueName1 := GenerateQueueName(sub1)
+
+	sub2 := Subscription{
+		GroupID: "TestGroup",
+		Topics:  []string{"Topic_2", "Topic_1"},
+	}
+	queueName2 := GenerateQueueName(sub2)
+
+	//Test that different ordering of topics results in the same name
+	assert.Equal(queueName1, queueName2)
+
+	sub3 := Subscription{
+		GroupID: "TestGroup_2",
+		Topics:  []string{"Topic_1", "Topic_2"},
+	}
+	queueName3 := GenerateQueueName(sub3)
+
+	//Test that a new GroupID gets a different name
+	assert.NotEqual(queueName1, queueName3)
+
+	sub4 := Subscription{
+		GroupID: "TestGroup",
+		Topics:  []string{"Topic_1", "Topic_2"},
+		Headers: map[string]string{"Header_1": "Value_1", "Header_2": "Value_2"},
+	}
+	queueName4 := GenerateQueueName(sub4)
+
+	//Test that adding headers gets a different name
+	assert.NotEqual(queueName1, queueName4)
+
+	sub5 := Subscription{
+		GroupID: "TestGroup",
+		Topics:  []string{"Topic_1", "Topic_2"},
+		Headers: map[string]string{"Header_2": "Value_2", "Header_1": "Value_1"},
+	}
+	queueName5 := GenerateQueueName(sub5)
+
+	//Test that changing how the headers are ordered generates the same name
+	assert.Equal(queueName4, queueName5)
+}


### PR DESCRIPTION
Signed-off-by: Andrew Kunzel <akunzel@pinpoint.com>

**JIRA:** https://pinpt-hq.atlassian.net/browse/BOLT-186

Provide a clear PR title prefixed with `BE-XXX`

**Description:**

This moves the Queue name generation from event-api repo to go-common. A follow up 