### PR TITLE
add support for decoding json strings for filter expression

### DIFF
--- a/filterexpr/grammar.peg
+++ b/filterexpr/grammar.peg
@@ -5,6 +5,7 @@ import (
     "fmt"
     "strings"
     "regexp"
+    "encoding/json"
 
     pjson "github.com/pinpt/go-common/v10/json"
 )
@@ -44,39 +45,43 @@ func toString(val interface{}) string {
     return pjson.Stringify(val)
 }
 
+func (n *Node) matchVal(theval string, val interface{}, kv map[string]interface{}) bool {
+    if kv, ok := val.([]string); ok {
+        for i := 0; i < len(kv); i++ {
+            if n.RegExp {
+                if n.re.MatchString(kv[i]) {
+                    return true
+                }
+            } else if kv[i] == theval {
+                return true
+            }
+        }
+        return false
+    }
+    if kv, ok := val.([]interface{}); ok {
+        for i := 0; i < len(kv); i++ {
+            kval := toString(kv[i])
+            if n.RegExp {
+                if n.re.MatchString(kval) {
+                    return true
+                }
+            } else if kval == theval {
+                return true
+            }
+        }
+        return false
+    }
+    sval := toString(val)
+    if n.RegExp {
+        return n.re.MatchString(sval)
+    }
+    return theval == sval
+}
+
 func (n *Node) Test(kv map[string]interface{}) bool {
     val, ok := kv[n.Key]
     if ok{
-        if kv, ok := val.([]string); ok {
-            for i := 0; i < len(kv); i++ {
-                if n.RegExp {
-                    if n.re.MatchString(kv[i]) {
-                        return true
-                    }
-                } else if kv[i] == n.Value {
-                    return true
-                }
-            }
-            return false
-        }
-        if kv, ok := val.([]interface{}); ok {
-            for i := 0; i < len(kv); i++ {
-                kval := toString(kv[i])
-                if n.RegExp {
-                    if n.re.MatchString(kval) {
-                        return true
-                    }
-                } else if kval == n.Value {
-                    return true
-                }
-            }
-            return false
-        }
-        sval := toString(val)
-        if n.RegExp {
-            return n.re.MatchString(sval)
-        }
-        return n.Value == sval
+        return n.matchVal(n.Value, val, kv)
     } else {
         if n.Value == null {
             return true
@@ -85,13 +90,18 @@ func (n *Node) Test(kv map[string]interface{}) bool {
     if strings.Contains(n.Key, ".") {
         val, _ := pjson.DottedFind(n.Key, kv)
         if val == nil {
-            return false
+            tok := strings.Split(n.Key, ".")
+            sval := kv[tok[0]]
+            // looks like a string of JSON
+            if s, ok := sval.(string); ok && s[0:1] == "{" && s[len(s) - 1:] == "}" {
+                svalkv := make(map[string]interface{})
+                json.Unmarshal([]byte(s), &svalkv)
+                val, _ = pjson.DottedFind(strings.Join(tok[1:], "."), svalkv)
+            } else {
+                return false
+            }
         }
-        sval := toString(val)
-        if n.RegExp {
-            return n.re.MatchString(sval)
-        }
-        return n.Value == sval
+        return n.matchVal(n.Value, val, kv)
     }
     return n.Value == ""
 }


### PR DESCRIPTION
**JIRA:** https://pinpt-hq.atlassian.net/browse/GOLD-300

**Description:**

Add support for matching a filter expression against JSON encoded as a string (such as we do in db change)

So let's say you have this normal db change type object:

```json
{
	"action": "UPSERT",
	"change_date": {
		"epoch": 1600183776694,
		"offset": 0,
		"rfc3339": "2020-09-15T15:29:36.694+00:00"
	},
	"customer_id": "a8a78d9c16839b97",
	"data": "{\"_id\":\"088700e68ca935c2\",\"active\":false,\"attendee_ids\":[\"ff1f0458cfe3e85d\",\"579dc0e39f8f8bf8\"],\"attendee_ref_id\":\"\",\"busy\":false,\"calendar_id\":\"\",\"created_ts\":1600183776664,\"customer_id\":\"a8a78d9c16839b97\",\"description\":\"\",\"end_date\":{\"epoch\":1600182000000,\"offset\":-300,\"rfc3339\":\"2020-09-15T10:00:00-05:00\"},\"integration_instance_id\":\"fa191e168d0cdde8\",\"location\":{\"details\":\"\",\"name\":\"\",\"url\":\"https://meet.google.com/mia-cwgr-eih\"},\"name\":\"Gold Miners Standup\",\"owner\":{\"avatar_url\":\"https://lh3.googleusercontent.com/a-/AOh14GgENnGHM7EV8a9hMKeg8Up4zzD7em_0Abi-177x\",\"id\":\"b3810254256536ef\",\"name\":\"Robin Diddams\",\"nickname\":\"Robin\",\"profile_id\":\"79f9ee0efd869eb5\",\"ref_id\":\"579dc0e39f8f8bf8\",\"ref_type\":\"gcal\",\"team_id\":\"06fc70d80fdd028f\",\"type\":\"TRACKABLE\",\"url\":null},\"owner_ref_id\":\"579dc0e39f8f8bf8\",\"participants\":[],\"ref_id\":\"3kaqtn5lkri8iir1nba94mqt17_20200915T143000Z\",\"ref_type\":\"gcal\",\"start_date\":{\"epoch\":1600180200000,\"offset\":-300,\"rfc3339\":\"2020-09-15T09:30:00-05:00\"},\"status\":\"CONFIRMED\",\"updated_ts\":1600183776664,\"url\":\"https://www.google.com/calendar/event?eid=M2thcXRuNWxrcmk4aWlyMW5iYTk0bXF0MTdfMjAyMDA5MTVUMTQzMDAwWiByZGlkZGFtc0BwaW5wb2ludC5jb20\"}",
	"hashcode": "06556540c8ccaa4a",
	"id": "b20a52408f2df27d",
	"integration_instance_id": null,
	"model": "pipeline.calendar.Event",
	"ref_id": "088700e68ca935c2",
	"ref_type": ""
}
```

The `data` payload for a db change is JSON but encoded as a string. So you can't currently use an object filter expression to match values inside it.

But ... now you can.   Basically, if the string looks like JSON and it doesn't match, i'll try and fall back match against the decoded value.

So this now works:

```
data.attendee_ids:"ff1f0458cfe3e8ee" OR data.attendee_ids:"579dc0e39f8f8bf8"
```

as a filter expression.


