### PR TITLE
WriteHeader is to be called _after_ all headers are set

### DIFF
--- a/httpmessage/http.go
+++ b/httpmessage/http.go
@@ -20,13 +20,13 @@ type jsonResponse struct {
 
 // RenderStatus will render an appropriate message detail
 func RenderStatus(w http.ResponseWriter, req *http.Request, status int, title, msg string) {
-	w.WriteHeader(status)
 	w.Header().Set("Cache-Control", "max-age=0,no-cache,no-store")
 	accept := req.Header.Get("accept")
 	ct := req.Header.Get("content-type")
 	rw := req.Header.Get("x-requested-with") == "XMLHttpRequest"
 	if strings.Contains(accept, "json") || rw || strings.Contains(ct, "json") {
 		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
 		w.Write([]byte(pjson.Stringify(jsonResponse{false, msg})))
 		return
 	}
@@ -37,5 +37,6 @@ func RenderStatus(w http.ResponseWriter, req *http.Request, status int, title, m
 	} else {
 		message = msg
 	}
+	w.WriteHeader(status)
 	tmpl.Execute(w, templateParams{title, message, err})
 }


### PR DESCRIPTION
**Description:**
As per their [docs](https://golang.org/src/net/http/server.go?s=3003:5866#L85):
`Changing the header map after a call to WriteHeader (or Write) has no effect unless the modified headers are trailers.`

so `Cache-Control` and `Content-Type` are never set