### PR TITLE
move back to no-wait true when cancelling a subscription; don't need to wait since it's an ackable queue

### DIFF
--- a/rabbitmq/rabbitmq.go
+++ b/rabbitmq/rabbitmq.go
@@ -254,7 +254,7 @@ func (session *Session) startConsumeLoop(consumergroup string, autoAck bool, exc
 
 			err := session.consumerchannelhost.Channel.Cancel(
 				consumergroup, // Consumer
-				false,          // No-Wait
+				true,          // No-Wait
 			)
 			if err != nil {
 				log.Error(session.logger, "error closing channel on exit", "err", err)


### PR DESCRIPTION
This was the only other change that went out this afternoon, so either there's a consumer leak that sprung up again, or the nowait bit is not working as expected and keeping consumers around after they should be cancelled.

**JIRA:** https://pinpt-hq.atlassian.net/browse/BE-XXX

Provide a clear PR title prefixed with `BE-XXX`

**Description:**
