### PR TITLE
NAN-543: smartshovel addition to rabbitmq common code

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -32,6 +32,9 @@ var EventDebug = os.Getenv("PP_EVENT_DEBUG") == "1"
 
 const jsonContentType = "application/json"
 
+// IngestQueueName is the name of the eventapi ingest queue
+const IngestQueueName = "event-api-ingest"
+
 // PublishEvent is the container for a model event
 type PublishEvent struct {
 	Object  datamodel.Model
@@ -841,6 +844,10 @@ type Subscription struct {
 
 //GenerateQueueName takes in a Subscription, extracts the headers and topics and returns a consistent but unique queue name
 func GenerateQueueName(subscription Subscription) string {
+	// if the queue name is IngestQueueName, short circuit and just return the groupid = queue name, since we need this to be static
+	if subscription.GroupID == IngestQueueName {
+		return IngestQueueName
+	}
 	hashkeys := []string{}
 	for k, v := range subscription.Headers {
 		hashkeys = append(hashkeys, k, v)
@@ -852,6 +859,8 @@ func GenerateQueueName(subscription Subscription) string {
 	// sort so the hash is consistent
 	sort.Strings(hashkeys)
 	queueName := subscription.GroupID + "-" + hash.Values(hashkeys) // has the matching headers and topics so we create a consistent but unique queue
+
+
 
 	return queueName
 }

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -707,4 +707,13 @@ func TestGenerateQueueName(t *testing.T) {
 
 	//Test that changing how the headers are ordered generates the same name
 	assert.Equal(queueName4, queueName5)
+
+	sub6 := Subscription{
+		GroupID: IngestQueueName,
+		Topics:  []string{"atopic",},
+	}
+	queueName6 := GenerateQueueName(sub6)
+
+	//Test that using the ingestqueuename results in the same name
+	assert.Equal(IngestQueueName, queueName6)
 }

--- a/rabbitmqsmartshovel/rabbitmqsmartshovel.go
+++ b/rabbitmqsmartshovel/rabbitmqsmartshovel.go
@@ -125,10 +125,21 @@ func (session *Session) ensureQueueAndBindings() error {
 		channel.Close()
 		return err
 	}
+
+	exchange := session.config.Exchange
+
+	// if the session IS the shovel session, then we bind ourselves to the ingest exchange
+	if session.config.IsShovel {
+		exchange = session.config.IngestExchange
+	} else if session.config.IsSubscriptionQueueListener {
+		// if this is the special shovel that keeps all the shovels' subscription caches in sync, override some things..
+		exchange = session.config.SubscriptionExchange
+	}
+
 	if err := session.consumerchannelhost.Channel.QueueBind(
-		session.config.Name,     // queue name
-		session.config.Name,     // routing key
-		session.config.Exchange, // exchange
+		session.config.Name, // queue name
+		session.config.Name, // routing key
+		exchange,            // exchange
 		false,
 		nil,
 	); err != nil {

--- a/rabbitmqsmartshovel/rabbitmqsmartshovel.go
+++ b/rabbitmqsmartshovel/rabbitmqsmartshovel.go
@@ -143,7 +143,7 @@ func (session *Session) ensureQueueAndBindings() error {
 		false,
 		nil,
 	); err != nil {
-		log.Error(session.logger, "error binding routing key", "err", err, "routingKey", session.config.Name)
+		log.Error(session.logger, "error binding routing key", "err", err, "routingKey", session.config.Name, "exchange", session.config.Exchange)
 		channel.Close()
 		return err
 	}

--- a/rabbitmqsmartshovel/rabbitmqsmartshovel.go
+++ b/rabbitmqsmartshovel/rabbitmqsmartshovel.go
@@ -19,9 +19,7 @@ type Config struct {
 	ID                          string
 	Exchange                    string
 	IngestExchange              string
-	IngestQueueName             string
 	SubscriptionExchange        string
-	SubscriptionQueueName       string
 	IsShovel                    bool
 	IsSubscriptionQueueListener bool
 	ConsumerConnectionPool      *rabbitmq.ConnectionPool
@@ -208,10 +206,10 @@ func (session *Session) Push(routingKey string, data amqp.Publishing) error {
 	} else if session.config.IsSubscriptionQueueListener {
 		// if this is the special shovel that keeps all the shovels' subscription caches in sync, override some things..
 		exchange = session.config.SubscriptionExchange
-		routingKey = session.config.SubscriptionQueueName
+		routingKey = session.config.SubscriptionExchange
 	} else {
 		// since we're using a direct exchange now, a routeingkey = queuename will get the message to the right queue
-		routingKey = session.config.IngestQueueName
+		routingKey = session.config.IngestExchange
 	}
 	return session.config.PublisherConnectionPool.Push(exchange, routingKey, data)
 }

--- a/rabbitmqsmartshovel/rabbitmqsmartshovel.go
+++ b/rabbitmqsmartshovel/rabbitmqsmartshovel.go
@@ -1,0 +1,341 @@
+package rabbitmqsmartshovel
+
+import (
+	"context"
+	"errors"
+	"github.com/pinpt/go-common/v10/rabbitmq"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pinpt/go-common/v10/log"
+	pstrings "github.com/pinpt/go-common/v10/strings"
+	"github.com/streadway/amqp"
+)
+
+// Config for the session
+type Config struct {
+	Name                    string
+	ID                      string
+	Exchange                string
+	IngestExchange          string
+	IsShovel                bool
+	ConsumerConnectionPool  *rabbitmq.ConnectionPool
+	PublisherConnectionPool *rabbitmq.ConnectionPool
+	AutoAck                 bool
+	DurableQueue            bool
+	DeleteUnused            bool
+	Exclusive               bool
+	Args                    amqp.Table
+	Qos                     int
+	PublishOnly             bool
+	Context                 context.Context
+}
+
+// Session is the rabbitmq session
+type Session struct {
+	messages             chan amqp.Delivery
+	logger               log.Logger
+	config               *Config
+	name                 string
+	consumerchannelhost  *rabbitmq.ChannelHost
+	publisherchannelhost *rabbitmq.ChannelHost
+	done                 chan bool
+	mu                   sync.RWMutex
+	bindings             []string
+	autocommit           bool
+	inflightmessages     map[uint64]bool
+}
+
+const (
+	// When reconnecting to the server after connection failure
+	reconnectDelay = 2 * time.Second
+
+	// When setting up the channel after a channel exception
+	reInitDelay = 10 * time.Millisecond
+
+	// When sending how long to wait for confirm before bailing
+	sendTimeout = 5 * time.Second
+)
+
+var (
+	// ErrNotConnected is returned when not connected to a server
+	ErrNotConnected = errors.New("not connected to a server")
+	// ErrAlreadyClosed is returned when the connection is already closed
+	ErrAlreadyClosed = errors.New("already closed: not connected to the server")
+	// ErrShutdown is returned when already shutting down
+	ErrShutdown = errors.New("session is shutting down")
+	// ErrNack is returned when a message publish fails with a NACK
+	ErrNack = errors.New("message was not sent")
+	// ErrServerBusy is returned when there is too much tcp backpressure on a channel
+	ErrServerBusy = errors.New("server busy; message was not sent")
+	// ErrPublishOnly is returned when a channel is publish only and you try and use a queue function
+	ErrPublishOnly = errors.New("channel is publish only")
+	// ErrTimedOut is returned when a message times out waiting for confirmation
+	ErrTimedOut = errors.New("confirmation timed out")
+)
+
+// New creates a new consumer state instance, and automatically
+// attempts to connect to the server.
+func New(logger log.Logger, config Config) *Session {
+	if config.Name == "" {
+		config.Name = pstrings.NewUUIDV4()
+	}
+
+	// set a default QoS
+	if config.Qos <= 0 {
+		config.Qos = 1
+	}
+
+	session := Session{
+		logger:   log.With(logger, "pkg", "rabbitmq", "name", config.Name),
+		config:   &config,
+		done:     make(chan bool),
+		messages: make(chan amqp.Delivery, 1),
+	}
+	// ensure our queue and binding are all setup
+	session.ensureConsumerChannel()
+
+	return &session
+}
+
+// init will initialize channel & declare queue
+func (session *Session) ensureQueueAndBindings() error {
+	if session.config.PublishOnly {
+		return ErrPublishOnly
+	}
+	channel, err := session.config.ConsumerConnectionPool.GetTransientChannel(false)
+	if err != nil {
+		log.Error(session.logger, "error getting channel to create queue", "err", err)
+
+	}
+	log.Info(session.logger, "staring queue create", "queuename", session.config.Name)
+	// since we're using a shovel
+	if _, err := channel.QueueDeclare(
+		session.config.Name,
+		session.config.DurableQueue, // Durable
+		session.config.DeleteUnused, // Delete when unused
+		session.config.Exclusive,    // Exclusive
+		false,                       // No-wait
+		session.config.Args,         // Arguments
+	); err != nil {
+		log.Error(session.logger, "error declaring queue", "err", err)
+		channel.Close()
+		return err
+	}
+
+	log.Info(session.logger, "setup and ready")
+	channel.Close()
+
+	return nil
+}
+
+func (session *Session) ensurePublisherChannel() *rabbitmq.ChannelHost {
+
+	for {
+		// Has to use an Ackable channel for Publish Confirmations.
+		chanHost, err := session.config.PublisherConnectionPool.GetChannel()
+		log.Debug(session.logger, "getting channel from pool to publish")
+
+		if err != nil {
+			log.Error(session.logger, "error with getting channel...retrying", "err", err)
+			session.config.PublisherConnectionPool.ReturnChannel(chanHost, true) // this will just close the channel
+			chanHost = nil
+			time.Sleep(reInitDelay)
+			continue
+		} else {
+			session.mu.Lock()
+			session.publisherchannelhost = chanHost
+			session.mu.Unlock()
+			return chanHost
+		}
+
+	}
+}
+
+func (session *Session) ensureConsumerChannel() {
+
+	for {
+		// Has to use an Ackable channel for Publish Confirmations.
+		chanHost, err := session.config.ConsumerConnectionPool.GetChannel()
+		log.Debug(session.logger, "getting channel from pool to consume")
+
+		if err != nil {
+			log.Error(session.logger, "error with getting channel...retrying", "err", err)
+			session.config.ConsumerConnectionPool.ReturnChannel(chanHost, true)
+			chanHost = nil
+			time.Sleep(reInitDelay)
+			continue
+		} else {
+			session.mu.Lock()
+			session.consumerchannelhost = chanHost
+			// ensure our queue and binding are all setup
+			prefetch := session.config.Qos
+			session.mu.Unlock()
+
+			// Configure RabbitMQ channel QoS for Consumer
+			session.consumerchannelhost.Channel.Qos(prefetch, 0, false)
+			session.ensureQueueAndBindings()
+
+			return
+		}
+	}
+}
+
+// Push will publish data to channel
+func (session *Session) Push(routingKey string, data amqp.Publishing) error {
+	exchange := session.config.IngestExchange
+	// if the session IS the shovel session, then we publish to the Main EventAPI exchange
+	// otherwise just publish to the IngestExchange
+	if session.config.IsShovel {
+		exchange = session.config.Exchange
+	}
+	return session.config.PublisherConnectionPool.Push(exchange, routingKey, data)
+}
+
+// Stream will continuously put queue items on the channel.
+// It is required to call delivery.Ack when it has been
+// successfully processed, or delivery.Nack when it fails.
+// Ignoring this will cause data to build up on the server.
+func (session *Session) Stream(consumergroup string, autoAck bool, exclusive bool) (chan amqp.Delivery, error) {
+	if session.config.PublishOnly {
+		return nil, ErrPublishOnly
+	}
+	session.mu.Lock()
+	session.autocommit = autoAck
+	session.mu.Unlock()
+	go session.startConsumeLoop(consumergroup, autoAck, exclusive)
+	return session.messages, nil
+}
+
+// adapted from: https://github.com/houseofcat/turbocookedrabbit
+func (session *Session) startConsumeLoop(consumergroup string, autoAck bool, exclusive bool) {
+	log.Info(session.logger, "starting consume loop for", "consumer", consumergroup)
+
+	for {
+		log.Info(session.logger, "starting connection for", "consumer", consumergroup)
+
+		// Initiate consuming process.
+		deliveryChan, err := session.consumerchannelhost.Channel.Consume(
+			session.config.Name,
+			consumergroup, // Consumer
+			autoAck,       // Auto-Ack
+			exclusive,     // Exclusive
+			false,         // No-local
+			false,         // No-Wait
+			nil,           // Args
+		)
+		log.Info(session.logger, "consuming", "consumer", consumergroup)
+
+		if err != nil {
+			if strings.Contains(err.Error(), "PRECONDITION_FAILED") {
+
+				// try to cleanup
+				ch, _ := session.config.ConsumerConnectionPool.GetTransientChannel(false)
+				log.Warn(session.logger, "queue precondition failed, will try and delete and try again", "err", err, "queue", session.config.Name)
+				ch.QueueDelete(session.config.Name, false, true, false)
+				ch.Close()
+				continue
+			}
+			session.config.ConsumerConnectionPool.ReturnChannel(session.consumerchannelhost, true)
+			session.ensureConsumerChannel()
+			log.Error(session.logger, "consumer's current channel closed", "err", err)
+			continue
+		}
+		// Process delivered messages by the consumer, returns true when we are to stop all consuming.
+		if session.processDeliveries(deliveryChan, session.consumerchannelhost) {
+			log.Debug(session.logger, "process deliveries exited")
+
+			err := session.consumerchannelhost.Channel.Cancel(
+				consumergroup, // Consumer
+				true,          // No-Wait
+			)
+			if err != nil {
+				log.Error(session.logger, "error closing channel on exit", "err", err)
+			}
+			session.done <- true
+			return
+		}
+		log.Error(session.logger, "error occurred processing deliveries, attempting to reconnect")
+	}
+}
+
+// ProcessDeliveries is the inner loop for processing the deliveries and returns true to break outer loop.
+// adapted from: https://github.com/houseofcat/turbocookedrabbit
+func (session *Session) processDeliveries(deliveryChan <-chan amqp.Delivery, chanHost *rabbitmq.ChannelHost) bool {
+
+	for {
+		// Listen for channel closure (close errors).
+		select {
+		case errorMessage := <-session.consumerchannelhost.Errors:
+			if errorMessage != nil {
+				log.Error(session.logger, "consumer's current channel errored...starting reconnect", "err", errorMessage, "reason", errorMessage.Reason, "code", errorMessage.Code)
+				session.config.ConsumerConnectionPool.ReturnChannel(chanHost, true)
+
+				session.ensureConsumerChannel()
+				return false
+			}
+
+		case <-session.config.Context.Done():
+			log.Debug(session.logger, "consumer context cancelled")
+			return true
+		case delivery := <-deliveryChan:
+			// broker the amqp delivery channel through our session channel so we can surive a reconnect
+			session.messages <- delivery
+		}
+
+	}
+}
+
+// Ack a consumer tag
+func (session *Session) Ack(tag uint64) error {
+	log.Debug(session.logger, "ack", "tag", tag, "autocommit", session.autocommit)
+
+	session.mu.RLock()
+	if session.autocommit {
+		session.mu.RUnlock()
+		return nil
+	}
+	session.mu.RUnlock()
+
+	err := session.consumerchannelhost.Channel.Ack(tag, false)
+
+	return err
+}
+
+// Nack a consumer tag
+func (session *Session) Nack(tag uint64) error {
+
+	log.Debug(session.logger, "nack", "tag", tag, "autocommit", session.autocommit)
+	session.mu.RLock()
+	if session.autocommit {
+		session.mu.RUnlock()
+		return nil
+	}
+	session.mu.RUnlock()
+
+	// if we get here, this means `NACK` was sent manually through the socket, so requeue
+	err := session.consumerchannelhost.Channel.Nack(tag, false, true)
+
+	return err
+}
+
+// Close will cleanly shutdown the channel and connection.
+func (session *Session) Close() error {
+	var err error
+	log.Debug(session.logger, "start shutdown of rabbit session")
+	session.mu.Lock()
+	// block until we've nacked anyting in flight
+	<-session.done
+
+	session.config.ConsumerConnectionPool.ReturnChannel(session.consumerchannelhost, false)
+	close(session.messages)
+	close(session.done)
+	session.consumerchannelhost = nil
+	session.publisherchannelhost = nil
+	session.mu.Unlock()
+	log.Debug(session.logger, "...waiting for shutdown of rabbit session")
+	log.Debug(session.logger, "rabbit session closed")
+
+	return err
+}


### PR DESCRIPTION
Adds an additional implementation of the rabbitmq session for a smartshovel.

This adds the necessary logic to publish to the EventApi-output exchange or the Ingest Exchange depending if the session is a shovel or not.

Since the smartshovel uses a direct exchange instead of topic binding, it made sense to keep around the topic exchange session that we had in case we need to rollback and keep using it. (Or if other things we use need a topic-based session, it works!)